### PR TITLE
Adds a certificate data source

### DIFF
--- a/dnsimple/data_source_dnsimple_certificate.go
+++ b/dnsimple/data_source_dnsimple_certificate.go
@@ -1,0 +1,74 @@
+package dnsimple
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceDNSimpleCertificate() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceDNSimpleCertificateRead,
+		Schema: map[string]*schema.Schema{
+			"domain": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"certificate_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"server_certificate": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"root_certificate": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"certificate_chain": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+
+			"private_key": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceDNSimpleCertificateRead(d *schema.ResourceData, meta interface{}) error {
+	provider := meta.(*Client)
+
+	certificate_id, err := strconv.Atoi(d.Get("certificate_id").(string))
+	if err != nil {
+		return fmt.Errorf("Error converting Certificate ID: %s", err)
+	}
+
+	cert, err := provider.client.Certificates.DownloadCertificate(provider.config.Account, d.Get("domain").(string), certificate_id)
+
+	if err != nil {
+		return fmt.Errorf("Couldn't find DNSimple SSL Certificate: %s", err)
+	}
+
+	certificate := cert.Data
+	d.Set("server_certificate", certificate.ServerCertificate)
+	d.Set("root_certificate", certificate.RootCertificate)
+	d.Set("certificate_chain", certificate.IntermediateCertificates)
+
+	key, err := provider.client.Certificates.GetCertificatePrivateKey(provider.config.Account, d.Get("domain").(string), certificate_id)
+
+	d.Set("private_key", key.Data.PrivateKey)
+	d.SetId(time.Now().UTC().String())
+
+	return nil
+}

--- a/dnsimple/data_source_dnsimple_certificate_test.go
+++ b/dnsimple/data_source_dnsimple_certificate_test.go
@@ -1,0 +1,35 @@
+package dnsimple
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDNSimpleCertificate_Basic(t *testing.T) {
+	domain := os.Getenv("DNSIMPLE_DOMAIN")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testAccCheckDNSimpleCertificateConfig_basic, domain),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"dnsimple_certificate.foobar", "domain", "hashicorp.com"),
+					resource.TestCheckResourceAttr(
+						"dnsimple_certificate.foobar", "certificate_id", "7"),
+				),
+			},
+		},
+	})
+}
+
+const testAccCheckDNSimpleCertificateConfig_basic = `
+data "dnsimple_certificate" "foobar" {
+	domain         = "%s"
+	certificate_id = "7"
+}`

--- a/dnsimple/provider.go
+++ b/dnsimple/provider.go
@@ -33,6 +33,10 @@ func Provider() terraform.ResourceProvider {
 			},
 		},
 
+		DataSourcesMap: map[string]*schema.Resource{
+			"dnsimple_certificate": dataSourceDNSimpleCertificate(),
+		},
+
 		ResourcesMap: map[string]*schema.Resource{
 			"dnsimple_record": resourceDNSimpleRecord(),
 		},

--- a/website/dnsimple.erb
+++ b/website/dnsimple.erb
@@ -10,6 +10,15 @@
         <a href="/docs/providers/dnsimple/index.html">DNSimple Provider</a>
                 </li>
 
+        <li<%= sidebar_current("docs-dnsimple-datasource") %>>
+        <a href="#">Data Sources</a>
+            <ul class="nav nav-visible">
+                <li<%= sidebar_current("docs-dnsimple-datasource-certificate") %>>
+                    <a href="/docs/providers/aws/d/certificate.html">dnsimple_certificate</a>
+                </li>
+        </ul>
+        </li>
+
         <li<%= sidebar_current("docs-dnsimple-resource") %>>
         <a href="#">Resources</a>
                 <ul class="nav nav-visible">

--- a/website/docs/d/certificate.html.markdown
+++ b/website/docs/d/certificate.html.markdown
@@ -1,0 +1,36 @@
+---
+layout: "dnsimple"
+page_title: "DNSimple: dnsimple_certificate"
+sidebar_current: "docs-dnsimple-datasource-certificate"
+description: |-
+  Provides a DNSimple certificate data source.
+---
+
+# dnsimple\_certificate
+
+Provides a DNSimple certificate data source.
+
+## Example Usage
+
+```hcl
+data "dnsimple_certificate" "foobar" {
+  domain           = "${var.dnsimple_domain}"
+  certificate_id   = "${var.dnsimple_certificate_id}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `domain` - (Required) The domain of the SSL Certificate
+* `certificate_id` - (Required) The ID of the SSL Certificate
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `server_certificate` - The SSL Certificate
+* `root_certificate` - The Root Certificate of the issuing CA
+* `certificate_chain` - A list of certificates that make up the chain
+* `private_key` - The corresponding Private Key for the SSL Certificate


### PR DESCRIPTION
This allows SSL Certificates created in DNSimple to be applied to other terraform resources. Fixes #3 