### PR TITLE
Add ability to pass a custom user agent fragment

### DIFF
--- a/dnsimple/config.go
+++ b/dnsimple/config.go
@@ -23,6 +23,7 @@ type Config struct {
 	Sandbox  bool
 	Prefetch bool
 
+	userAgentExtra   string
 	terraformVersion string
 }
 
@@ -42,7 +43,13 @@ func (config *Config) Client() (*Client, diag.Diagnostics) {
 	tc := oauth2.NewClient(context.Background(), ts)
 
 	client := dnsimple.NewClient(tc)
-	client.SetUserAgent(fmt.Sprintf("HashiCorp Terraform/%s (+https://www.terraform.io) Terraform Plugin SDK/%s", config.terraformVersion, meta.SDKVersionString()))
+
+	userAgent := fmt.Sprintf("HashiCorp Terraform/%s (+https://www.terraform.io) Terraform Plugin SDK/%s", config.terraformVersion, meta.SDKVersionString())
+	if config.userAgentExtra != "" {
+		userAgent = fmt.Sprintf("%s %s", userAgent, config.userAgentExtra)
+	}
+	client.SetUserAgent(userAgent)
+
 	if config.Sandbox {
 		client.BaseURL = baseURLSandbox
 	}

--- a/dnsimple/provider.go
+++ b/dnsimple/provider.go
@@ -18,14 +18,12 @@ func Provider() *schema.Provider {
 				Description: "The API v2 token for API operations.",
 				Sensitive:   true,
 			},
-
 			"account": {
 				Type:        schema.TypeString,
 				Required:    true,
 				DefaultFunc: schema.EnvDefaultFunc("DNSIMPLE_ACCOUNT", nil),
 				Description: "The account for API operations.",
 			},
-
 			"sandbox": {
 				Type:        schema.TypeBool,
 				Optional:    true,
@@ -36,7 +34,12 @@ func Provider() *schema.Provider {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("PREFETCH", nil),
-				Description: "Flag to enable the prefetch of zone records",
+				Description: "Flag to enable the prefetch of zone records.",
+			},
+			"user_agent": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Custom string to append to the user agent used for sending HTTP requests to the API.",
 			},
 		},
 
@@ -55,14 +58,16 @@ func Provider() *schema.Provider {
 			terraformVersion := schema.Provider{}.TerraformVersion
 			if terraformVersion == "" {
 				// Terraform 0.12 introduced this field to the protocol
-				// We can therefore assume that if it's missing it's 0.10 or 0.11
+				// We can therefore assume that if it's missing is 0.10 or 0.11
 				terraformVersion = "0.11+compatible"
 			}
 			config := Config{
-				Token:            data.Get("token").(string),
-				Account:          data.Get("account").(string),
-				Sandbox:          data.Get("sandbox").(bool),
-				Prefetch:         data.Get("prefetch").(bool),
+				Token:    data.Get("token").(string),
+				Account:  data.Get("account").(string),
+				Sandbox:  data.Get("sandbox").(bool),
+				Prefetch: data.Get("prefetch").(bool),
+
+				userAgentExtra:   data.Get("user_agent").(string),
 				terraformVersion: terraformVersion,
 			}
 

--- a/dnsimple/provider_test.go
+++ b/dnsimple/provider_test.go
@@ -1,10 +1,13 @@
 package dnsimple
 
 import (
+	"context"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 var testAccProvider *schema.Provider
@@ -15,13 +18,49 @@ const ProviderNameDNSimple = "dnsimple"
 func init() {
 	testAccProvider = Provider()
 	testAccProviderFactories = map[string]func() (*schema.Provider, error){
-		ProviderNameDNSimple: func() (*schema.Provider, error) { return testAccProvider, nil },
+		ProviderNameDNSimple: func() (*schema.Provider, error) {
+			return testAccProvider, nil
+		},
+	}
+}
+
+func testAccPreCheck(t *testing.T) {
+	if v := os.Getenv("DNSIMPLE_TOKEN"); v == "" {
+		t.Fatal("DNSIMPLE_TOKEN must be set for acceptance tests")
+	}
+
+	if v := os.Getenv("DNSIMPLE_ACCOUNT"); v == "" {
+		t.Fatal("DNSIMPLE_ACCOUNT must be set for acceptance tests")
+	}
+
+	if v := os.Getenv("DNSIMPLE_DOMAIN"); v == "" {
+		t.Fatal("DNSIMPLE_DOMAIN must be set for acceptance tests. The domain is used to create and destroy record against.")
 	}
 }
 
 func TestProvider(t *testing.T) {
 	if err := Provider().InternalValidate(); err != nil {
 		t.Fatalf("err: %s", err)
+	}
+}
+
+func TestProvider_Impl(t *testing.T) {
+	var _ = Provider()
+}
+
+func TestProvider_CustomUserAgent(t *testing.T) {
+	raw := map[string]interface{}{
+		"token":      "a1b2c3d4f5",
+		"user_agent": "Consul/0.81",
+	}
+
+	provider := Provider()
+	provider.Configure(context.Background(), terraform.NewResourceConfigRaw(raw))
+	client := provider.Meta().(*Client)
+
+	want := "Consul/0.81"
+	if got := client.client.UserAgent; !strings.HasSuffix(got, want) {
+		t.Fatalf("Config UserAgent expected to end with `%v`, got `%v`", want, got)
 	}
 }
 
@@ -44,23 +83,5 @@ func TestProvider_prefetch(t *testing.T) {
 		if provider.config.Prefetch != true {
 			t.Fatal("Config Prefetch Flag does not equal True!")
 		}
-	}
-}
-
-func TestProvider_impl(t *testing.T) {
-	var _ = Provider()
-}
-
-func testAccPreCheck(t *testing.T) {
-	if v := os.Getenv("DNSIMPLE_TOKEN"); v == "" {
-		t.Fatal("DNSIMPLE_TOKEN must be set for acceptance tests")
-	}
-
-	if v := os.Getenv("DNSIMPLE_ACCOUNT"); v == "" {
-		t.Fatal("DNSIMPLE_ACCOUNT must be set for acceptance tests")
-	}
-
-	if v := os.Getenv("DNSIMPLE_DOMAIN"); v == "" {
-		t.Fatal("DNSIMPLE_DOMAIN must be set for acceptance tests. The domain is used to create and destroy record against.")
 	}
 }


### PR DESCRIPTION
The fragment will be appended at the very end of the default user-agent. This enables consumers of the Terraform provider to pass custom tokens to perform additional analytics.

As an example, we will be adding a custom token in the [Consul/DNSimple integration](https://github.com/dnsimple/terraform-dnsimple-cts) to be able to better monitor the usage of the Consul Integration.
