### PR TITLE
Pass the parent context to the calls created by the provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## main
+
+* Pass parent context to DNSimple client calls to propagate errors and handling cancellation
+
 ## 0.13.0
 
 * Added ability to pass a custom user agent fragment dnsimple/terraform-provider-dnsimple#56

--- a/dnsimple/config.go
+++ b/dnsimple/config.go
@@ -38,9 +38,9 @@ type Client struct {
 }
 
 // Client returns a new client for accessing DNSimple.
-func (config *Config) Client() (*Client, diag.Diagnostics) {
+func (config *Config) Client(ctx context.Context) (*Client, diag.Diagnostics) {
 	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: config.Token})
-	tc := oauth2.NewClient(context.Background(), ts)
+	tc := oauth2.NewClient(ctx, ts)
 
 	client := dnsimple.NewClient(tc)
 

--- a/dnsimple/datasource_dnsimple_certificate.go
+++ b/dnsimple/datasource_dnsimple_certificate.go
@@ -47,7 +47,7 @@ func dataSourceDNSimpleCertificate() *schema.Resource {
 	}
 }
 
-func dataSourceDNSimpleCertificateRead(_ context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceDNSimpleCertificateRead(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	provider := meta.(*Client)
 
 	certificateId, err := strconv.Atoi(data.Get("certificate_id").(string))
@@ -55,7 +55,7 @@ func dataSourceDNSimpleCertificateRead(_ context.Context, data *schema.ResourceD
 		return diag.Errorf("Error converting Certificate ID: %s", err)
 	}
 
-	cert, err := provider.client.Certificates.DownloadCertificate(context.Background(), provider.config.Account, data.Get("domain").(string), int64(certificateId))
+	cert, err := provider.client.Certificates.DownloadCertificate(ctx, provider.config.Account, data.Get("domain").(string), int64(certificateId))
 
 	if err != nil {
 		return diag.Errorf("Couldn't find DNSimple SSL Certificate: %s", err)
@@ -66,7 +66,7 @@ func dataSourceDNSimpleCertificateRead(_ context.Context, data *schema.ResourceD
 	data.Set("root_certificate", certificate.RootCertificate)
 	data.Set("certificate_chain", certificate.IntermediateCertificates)
 
-	key, err := provider.client.Certificates.GetCertificatePrivateKey(context.Background(), provider.config.Account, data.Get("domain").(string), int64(certificateId))
+	key, err := provider.client.Certificates.GetCertificatePrivateKey(ctx, provider.config.Account, data.Get("domain").(string), int64(certificateId))
 
 	data.Set("private_key", key.Data.PrivateKey)
 	data.SetId(time.Now().UTC().String())

--- a/dnsimple/datasource_dnsimple_zone.go
+++ b/dnsimple/datasource_dnsimple_zone.go
@@ -36,10 +36,10 @@ func datasourceDNSimpleZone() *schema.Resource {
 
 }
 
-func datasourceDNSimpleZoneRead(_ context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func datasourceDNSimpleZoneRead(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	provider := meta.(*Client)
 
-	resp, err := provider.client.Zones.GetZone(context.Background(), provider.config.Account, data.Get("name").(string))
+	resp, err := provider.client.Zones.GetZone(ctx, provider.config.Account, data.Get("name").(string))
 
 	if err != nil {
 		if strings.Contains(err.Error(), "404") {

--- a/dnsimple/provider.go
+++ b/dnsimple/provider.go
@@ -71,7 +71,7 @@ func Provider() *schema.Provider {
 				terraformVersion: terraformVersion,
 			}
 
-			return config.Client()
+			return config.Client(ctx)
 		},
 	}
 	return provider

--- a/dnsimple/resource_dnsimple_domain.go
+++ b/dnsimple/resource_dnsimple_domain.go
@@ -54,14 +54,14 @@ func resourceDNSimpleDomain() *schema.Resource {
 	}
 }
 
-func resourceDNSimpleDomainCreate(_ context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDNSimpleDomainCreate(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	provider := meta.(*Client)
 
 	domainAttributes := dnsimple.Domain{
 		Name: data.Get("name").(string),
 	}
 
-	response, err := provider.client.Domains.CreateDomain(context.Background(), provider.config.Account, domainAttributes)
+	response, err := provider.client.Domains.CreateDomain(ctx, provider.config.Account, domainAttributes)
 
 	if err != nil {
 		return diag.Errorf("Failed to create DNSimple Domain: %s", err)
@@ -69,15 +69,15 @@ func resourceDNSimpleDomainCreate(_ context.Context, data *schema.ResourceData, 
 
 	data.SetId(strconv.FormatInt(response.Data.ID, 10))
 
-	return resourceDNSimpleDomainRead(nil, data, meta)
+	return resourceDNSimpleDomainRead(ctx, data, meta)
 }
 
-func resourceDNSimpleDomainRead(_ context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDNSimpleDomainRead(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	provider := meta.(*Client)
 
 	domainID := data.Id()
 
-	response, err := provider.client.Domains.GetDomain(context.Background(), provider.config.Account, domainID)
+	response, err := provider.client.Domains.GetDomain(ctx, provider.config.Account, domainID)
 
 	if err != nil {
 		if strings.Contains(err.Error(), "404") {
@@ -101,14 +101,14 @@ func resourceDNSimpleDomainRead(_ context.Context, data *schema.ResourceData, me
 
 }
 
-func resourceDNSimpleDomainDelete(_ context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDNSimpleDomainDelete(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	provider := meta.(*Client)
 
 	log.Printf("[INFO] Deleting DNSimple Record: %s, %s", data.Get("name").(string), data.Id())
 
 	domainID := data.Id()
 
-	_, err := provider.client.Domains.DeleteDomain(context.Background(), provider.config.Account, domainID)
+	_, err := provider.client.Domains.DeleteDomain(ctx, provider.config.Account, domainID)
 	if err != nil {
 		return diag.Errorf("Error deleting DNSimple Record: %s", err)
 	}

--- a/dnsimple/resource_dnsimple_email_forward.go
+++ b/dnsimple/resource_dnsimple_email_forward.go
@@ -46,7 +46,7 @@ func resourceDNSimpleEmailForward() *schema.Resource {
 	}
 }
 
-func resourceDNSimpleEmailForwardCreate(_ context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDNSimpleEmailForwardCreate(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	provider := meta.(*Client)
 
 	emailForwardAttributes := dnsimple.EmailForward{
@@ -56,7 +56,7 @@ func resourceDNSimpleEmailForwardCreate(_ context.Context, data *schema.Resource
 
 	log.Printf("[DEBUG] DNSimple Email Forward create forwardAttributes: %#v", emailForwardAttributes)
 
-	resp, err := provider.client.Domains.CreateEmailForward(context.Background(), provider.config.Account, data.Get("domain").(string), emailForwardAttributes)
+	resp, err := provider.client.Domains.CreateEmailForward(ctx, provider.config.Account, data.Get("domain").(string), emailForwardAttributes)
 	if err != nil {
 		return diag.Errorf("Failed to create DNSimple EmailForward: %s", err)
 	}
@@ -64,10 +64,10 @@ func resourceDNSimpleEmailForwardCreate(_ context.Context, data *schema.Resource
 	data.SetId(strconv.FormatInt(resp.Data.ID, 10))
 	log.Printf("[INFO] DNSimple EmailForward ID: %s", data.Id())
 
-	return resourceDNSimpleEmailForwardRead(nil, data, meta)
+	return resourceDNSimpleEmailForwardRead(ctx, data, meta)
 }
 
-func resourceDNSimpleEmailForwardRead(_ context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDNSimpleEmailForwardRead(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	provider := meta.(*Client)
 
 	emailForwardID, err := strconv.ParseInt(data.Id(), 10, 64)
@@ -75,7 +75,7 @@ func resourceDNSimpleEmailForwardRead(_ context.Context, data *schema.ResourceDa
 		return diag.Errorf("Error converting Email Forward ID: %s", err)
 	}
 
-	resp, err := provider.client.Domains.GetEmailForward(context.Background(), provider.config.Account, data.Get("domain").(string), emailForwardID)
+	resp, err := provider.client.Domains.GetEmailForward(ctx, provider.config.Account, data.Get("domain").(string), emailForwardID)
 	if err != nil {
 		if strings.Contains(err.Error(), "404") {
 			log.Printf("DNSimple Email Forward Not Found - Refreshing from State")
@@ -95,13 +95,13 @@ func resourceDNSimpleEmailForwardRead(_ context.Context, data *schema.ResourceDa
 	return nil
 }
 
-func resourceDNSimpleEmailForwardUpdate(_ context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDNSimpleEmailForwardUpdate(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	log.Printf("[INFO] DNSimple doesn't support updating email forwards")
 
-	return resourceDNSimpleEmailForwardRead(nil, data, meta)
+	return resourceDNSimpleEmailForwardRead(ctx, data, meta)
 }
 
-func resourceDNSimpleEmailForwardDelete(_ context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDNSimpleEmailForwardDelete(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	provider := meta.(*Client)
 
 	log.Printf("[INFO] Deleting DNSimple EmailForward: %s, %s", data.Get("domain").(string), data.Id())
@@ -111,7 +111,7 @@ func resourceDNSimpleEmailForwardDelete(_ context.Context, data *schema.Resource
 		return diag.Errorf("Error converting EmailForward ID: %s", err)
 	}
 
-	_, err = provider.client.Domains.DeleteEmailForward(context.Background(), provider.config.Account, data.Get("domain").(string), emailForwardID)
+	_, err = provider.client.Domains.DeleteEmailForward(ctx, provider.config.Account, data.Get("domain").(string), emailForwardID)
 	if err != nil {
 		return diag.Errorf("Error deleting DNSimple EmailForward: %s", err)
 	}
@@ -119,7 +119,7 @@ func resourceDNSimpleEmailForwardDelete(_ context.Context, data *schema.Resource
 	return nil
 }
 
-func resourceDNSimpleEmailForwardImport(_ context.Context, data *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceDNSimpleEmailForwardImport(ctx context.Context, data *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	parts := strings.Split(data.Id(), "_")
 
 	if len(parts) != 2 {
@@ -129,7 +129,7 @@ func resourceDNSimpleEmailForwardImport(_ context.Context, data *schema.Resource
 	data.SetId(parts[1])
 	data.Set("domain", parts[0])
 
-	if err := resourceDNSimpleEmailForwardRead(nil, data, meta); err != nil {
+	if err := resourceDNSimpleEmailForwardRead(ctx, data, meta); err != nil {
 		return nil, fmt.Errorf(err[0].Summary)
 	}
 	return []*schema.ResourceData{data}, nil

--- a/dnsimple/resource_dnsimple_lets_encrypt_certificate.go
+++ b/dnsimple/resource_dnsimple_lets_encrypt_certificate.go
@@ -93,7 +93,7 @@ func resourceDNSimpleLetsEncryptCertificateRead(ctx context.Context, data *schem
 		domainID := data.Get("domain_id").(string)
 		certificateID, _ := strconv.ParseInt(data.Id(), 10, 64)
 
-		response, err := provider.client.Certificates.GetCertificate(context.Background(), provider.config.Account, domainID, certificateID)
+		response, err := provider.client.Certificates.GetCertificate(ctx, provider.config.Account, domainID, certificateID)
 
 		if err != nil {
 			if strings.Contains(err.Error(), "404") {
@@ -116,7 +116,7 @@ func resourceDNSimpleLetsEncryptCertificateRead(ctx context.Context, data *schem
 	return nil
 }
 
-func resourceDNSimpleLetsEncryptCertificateCreate(_ context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDNSimpleLetsEncryptCertificateCreate(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	provider := meta.(*Client)
 
 	domainID := data.Get("domain_id").(string)
@@ -127,7 +127,7 @@ func resourceDNSimpleLetsEncryptCertificateCreate(_ context.Context, data *schem
 		Name:      data.Get("name").(string),
 	}
 
-	response, err := provider.client.Certificates.PurchaseLetsencryptCertificate(context.Background(), provider.config.Account, domainID, certificateAttributes)
+	response, err := provider.client.Certificates.PurchaseLetsencryptCertificate(ctx, provider.config.Account, domainID, certificateAttributes)
 
 	if err != nil {
 		return diag.Errorf("Failed to purchase Let's Encrypt Certificate: %s", err)
@@ -135,7 +135,7 @@ func resourceDNSimpleLetsEncryptCertificateCreate(_ context.Context, data *schem
 
 	certificateID := response.Data.CertificateID
 
-	issueResponse, issueErr := provider.client.Certificates.IssueLetsencryptCertificate(context.Background(), provider.config.Account, domainID, certificateID)
+	issueResponse, issueErr := provider.client.Certificates.IssueLetsencryptCertificate(ctx, provider.config.Account, domainID, certificateID)
 
 	if issueErr != nil {
 		return diag.Errorf("Failed to issue Let's Encrypt Certificate: %s", issueErr)

--- a/dnsimple/resource_dnsimple_record.go
+++ b/dnsimple/resource_dnsimple_record.go
@@ -75,7 +75,7 @@ func deprecationWarning() {
 	fmt.Println("Please consider changing your configuration to use dnsimple_zone_record instead")
 }
 
-func resourceDNSimpleRecordCreate(_ context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDNSimpleRecordCreate(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	deprecationWarning()
 	provider := meta.(*Client)
 
@@ -94,7 +94,7 @@ func resourceDNSimpleRecordCreate(_ context.Context, data *schema.ResourceData, 
 
 	log.Printf("[DEBUG] DNSimple Record create recordAttributes: %#v", recordAttributes)
 
-	resp, err := provider.client.Zones.CreateRecord(context.Background(), provider.config.Account, data.Get("domain").(string), recordAttributes)
+	resp, err := provider.client.Zones.CreateRecord(ctx, provider.config.Account, data.Get("domain").(string), recordAttributes)
 	if err != nil {
 		return diag.Errorf("Failed to create DNSimple Record: %s", err)
 	}
@@ -102,10 +102,10 @@ func resourceDNSimpleRecordCreate(_ context.Context, data *schema.ResourceData, 
 	data.SetId(strconv.FormatInt(resp.Data.ID, 10))
 	log.Printf("[INFO] DNSimple Record ID: %s", data.Id())
 
-	return resourceDNSimpleRecordRead(nil, data, meta)
+	return resourceDNSimpleRecordRead(ctx, data, meta)
 }
 
-func resourceDNSimpleRecordRead(_ context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDNSimpleRecordRead(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	deprecationWarning()
 	provider := meta.(*Client)
 
@@ -114,7 +114,7 @@ func resourceDNSimpleRecordRead(_ context.Context, data *schema.ResourceData, me
 		return diag.Errorf("Error converting Record ID: %s", err)
 	}
 
-	resp, err := provider.client.Zones.GetRecord(context.Background(), provider.config.Account, data.Get("domain").(string), recordID)
+	resp, err := provider.client.Zones.GetRecord(ctx, provider.config.Account, data.Get("domain").(string), recordID)
 	if err != nil {
 		if strings.Contains(err.Error(), "404") {
 			log.Printf("DNSimple Record Not Found - Refreshing from State")
@@ -141,7 +141,7 @@ func resourceDNSimpleRecordRead(_ context.Context, data *schema.ResourceData, me
 	return nil
 }
 
-func resourceDNSimpleRecordUpdate(_ context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDNSimpleRecordUpdate(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	deprecationWarning()
 	provider := meta.(*Client)
 
@@ -169,15 +169,15 @@ func resourceDNSimpleRecordUpdate(_ context.Context, data *schema.ResourceData, 
 
 	log.Printf("[DEBUG] DNSimple Record update configuration: %#v", recordAttributes)
 
-	_, err = provider.client.Zones.UpdateRecord(context.Background(), provider.config.Account, data.Get("domain").(string), recordID, recordAttributes)
+	_, err = provider.client.Zones.UpdateRecord(ctx, provider.config.Account, data.Get("domain").(string), recordID, recordAttributes)
 	if err != nil {
 		return diag.Errorf("Failed to update DNSimple Record: %s", err)
 	}
 
-	return resourceDNSimpleRecordRead(nil, data, meta)
+	return resourceDNSimpleRecordRead(ctx, data, meta)
 }
 
-func resourceDNSimpleRecordDelete(_ context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDNSimpleRecordDelete(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	deprecationWarning()
 	provider := meta.(*Client)
 
@@ -188,7 +188,7 @@ func resourceDNSimpleRecordDelete(_ context.Context, data *schema.ResourceData, 
 		return diag.Errorf("Error converting Record ID: %s", err)
 	}
 
-	_, err = provider.client.Zones.DeleteRecord(context.Background(), provider.config.Account, data.Get("domain").(string), recordID)
+	_, err = provider.client.Zones.DeleteRecord(ctx, provider.config.Account, data.Get("domain").(string), recordID)
 	if err != nil {
 		return diag.Errorf("Error deleting DNSimple Record: %s", err)
 	}
@@ -196,7 +196,7 @@ func resourceDNSimpleRecordDelete(_ context.Context, data *schema.ResourceData, 
 	return nil
 }
 
-func resourceDNSimpleRecordImport(_ context.Context, data *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceDNSimpleRecordImport(ctx context.Context, data *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	deprecationWarning()
 	parts := strings.Split(data.Id(), "_")
 
@@ -207,7 +207,7 @@ func resourceDNSimpleRecordImport(_ context.Context, data *schema.ResourceData, 
 	data.SetId(parts[1])
 	data.Set("domain", parts[0])
 
-	if err := resourceDNSimpleRecordRead(nil, data, meta); err != nil {
+	if err := resourceDNSimpleRecordRead(ctx, data, meta); err != nil {
 		return nil, fmt.Errorf(err[0].Summary)
 	}
 	return []*schema.ResourceData{data}, nil

--- a/dnsimple/resource_dnsimple_zone_record_test.go
+++ b/dnsimple/resource_dnsimple_zone_record_test.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"os"
 	"strconv"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/dnsimple/dnsimple-go/dnsimple"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -303,7 +304,7 @@ func testZoneRecordInstanceStateDataV1() map[string]interface{} {
 
 func TestResourceExampleInstanceStateUpgradeV0(t *testing.T) {
 	expected := testZoneRecordInstanceStateDataV1()
-	actual, err := resourceDNSimpleZoneRecordInstanceStateUpgradeV0(nil, testZoneRecordInstanceStateDataV0(), nil)
+	actual, err := resourceDNSimpleZoneRecordInstanceStateUpgradeV0(context.Background(), testZoneRecordInstanceStateDataV0(), nil)
 	assert.NoError(t, err, "error migrating state")
 	assert.Equal(t, expected, actual)
 }

--- a/dnsimple/zone_record_cache.go
+++ b/dnsimple/zone_record_cache.go
@@ -2,13 +2,14 @@ package dnsimple
 
 import (
 	"context"
+
 	"github.com/dnsimple/dnsimple-go/dnsimple"
 )
 
-func fetchZoneRecords(provider *Client, accountId string, zoneName string, options *dnsimple.ZoneRecordListOptions) []dnsimple.ZoneRecord {
+func fetchZoneRecords(ctx context.Context, provider *Client, accountId string, zoneName string, options *dnsimple.ZoneRecordListOptions) []dnsimple.ZoneRecord {
 
 	if provider.cache[zoneName] == nil {
-		records, err := provider.client.Zones.ListRecords(context.Background(), accountId, zoneName, options)
+		records, err := provider.client.Zones.ListRecords(ctx, accountId, zoneName, options)
 		if err != nil {
 			return nil
 		}


### PR DESCRIPTION
This PR fixes the issues with error propagation made for the provider by using the parent context.

Additionally, it will handle the operation cancellation successfully.

Fixes #57 