### PR TITLE
Avoid panic when looking for a record and it does not exist on the prefetched list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## main
+
+* Avoid panic when looking for a record and it does not exist on the prefetched list
+
 ## 0.14.0
 
 * Pass parent context to DNSimple client calls to propagate errors and handling cancellation

--- a/dnsimple/zone_record_cache.go
+++ b/dnsimple/zone_record_cache.go
@@ -6,15 +6,14 @@ import (
 	"github.com/dnsimple/dnsimple-go/dnsimple"
 )
 
-func fetchZoneRecords(ctx context.Context, provider *Client, accountId string, zoneName string, options *dnsimple.ZoneRecordListOptions) []dnsimple.ZoneRecord {
-
+func fetchZoneRecords(ctx context.Context, provider *Client, accountId string, zoneName string, options *dnsimple.ZoneRecordListOptions) ([]dnsimple.ZoneRecord, error) {
 	if provider.cache[zoneName] == nil {
 		records, err := provider.client.Zones.ListRecords(ctx, accountId, zoneName, options)
 		if err != nil {
-			return nil
+			return nil, err
 		}
 		provider.cache[zoneName] = records.Data
 	}
 
-	return provider.cache[zoneName]
+	return provider.cache[zoneName], nil
 }


### PR DESCRIPTION
This will fix the panic when the record cannot be found instead of panicking

References #57 