### PR TITLE
Surface all API errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## master
 
-* Deprecate the use of `contact_id` in the `dnsimple_lets_encrypt_certificate` resource. The field is no longer in use and there is no replacement for it.
+* Deprecate the use of `contact_id` in the `dnsimple_lets_encrypt_certificate` resource. The field is no longer in use and there is no replacement for it. dnsimple/terraform-provider-dnsimple#62
+* Surface all API exceptions during a terraform run. dnsimple/terraform-provider-dnsimple#61
 
 ## 0.14.1
 

--- a/dnsimple/provider.go
+++ b/dnsimple/provider.go
@@ -82,7 +82,12 @@ func Provider() *schema.Provider {
 }
 
 func attributeErrorsToDiagnostics(err *dnsimple.ErrorResponse) diag.Diagnostics {
-	result := make([]diag.Diagnostic, 0, len(err.AttributeErrors))
+	result := make([]diag.Diagnostic, 0, len(err.AttributeErrors)+1)
+
+	result = append(result, diag.Diagnostic{
+		Severity: diag.Error,
+		Summary:  fmt.Sprintf("API returned an error: %s", err.Message),
+	})
 
 	for field, errors := range err.AttributeErrors {
 		terraformField := translateFieldFromAPIToTerraform(field)


### PR DESCRIPTION
When errors are returned by the DNSimple API we use `attributeErrorsToDiagnostics` to unpack the errors and surface them. However, the implementation only handles `dnsimple.ErrorResponse.AttributeErrors` so when an error is not a `Validation failed` response nothing will be reported and the user will see the following:

```
        Error: Provider produced inconsistent result after apply

        When applying changes to dnsimple_zone_record.foobar, provider
        "provider[\"registry.terraform.io/hashicorp/dnsimple\"]" produced an
        unexpected new value: Root resource was present, but now absent.

        This is a bug in the provider, which should be reported in the provider's own
        issue tracker.
```

How we now report errors:

```
        Error: API returned an error: Validation failed

          with dnsimple_zone_record.foobar,
          on terraform_plugin_test.tf line 2, in resource "dnsimple_zone_record" "foobar":
           2: resource "dnsimple_zone_record" "foobar" {


        Error: API returned a Validation Error for: base

          with dnsimple_zone_record.foobar,
          on terraform_plugin_test.tf line 2, in resource "dnsimple_zone_record" "foobar":
           2: resource "dnsimple_zone_record" "foobar" {
```