### PR TITLE
Deprecate contact_id in certificate resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## master
+
+* Deprecate the use of `contact_id` in the `dnsimple_lets_encrypt_certificate` resource. The field is no longer in use and there is no replacement for it.
+
 ## 0.14.1
 
 * Avoid panic when looking for a record and it does not exist on the prefetched list

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,17 +43,9 @@ Our sandbox environment does not allow purchasing or issue certificates. For tha
 `resource_dnsimple_lets_encrypt_certificate` you will have to run the tests in production
 (setting `DNSIMPLE_SANDBOX=false` in the shell).
 
-For the Let's Encrypt Resource you will...
-   have to go to the `resource_dnsimple_lets_encrypt_certificate_test` and change the `domain` (line 21)
-to a real domain ID you want test against.
-
-After that you will have to change the `testAccLetsEncrypConfig` (in that same file) changing the arguments marked:
-   - contact_id (required)
-   - and name (optional, but you might have to change it if you run the tests for a second time)
-
-For the Certificate Data-Source you will...
-   have to go to the `datasource_dnsimple_certificate_test` and change the `certificate_id` in lines 26 and 39 to
-a real certificate ID in the domain you are going to test against.
+You will have to set the following env variables in your shell:
+   - `DNSIMPLE_CERTIFICATE_NAME` the name for which to request the certificate i.e. **www**
+   - `DNSIMPLE_CERTIFICATE_ID` the certificate ID used in the datasource test
 
 ## Sideload the plugin
 

--- a/dnsimple/datasource_dnsimple_certificate_test.go
+++ b/dnsimple/datasource_dnsimple_certificate_test.go
@@ -18,12 +18,12 @@ func TestAccDNSimpleCertificateBasic(t *testing.T) {
 			ProviderFactories: testAccProviderFactories,
 			Steps: []resource.TestStep{
 				{
-					Config: fmt.Sprintf(testAccCheckDNSimpleCertificateConfigBasic, domain),
+					Config: fmt.Sprintf(testAccCheckDNSimpleCertificateConfigBasic, domain, os.Getenv("DNSIMPLE_CERTIFICATE_ID")),
 					Check: resource.ComposeTestCheckFunc(
 						resource.TestCheckResourceAttr(
 							"data.dnsimple_certificate.foobar", "domain", domain),
 						resource.TestCheckResourceAttr(
-							"data.dnsimple_certificate.foobar", "certificate_id", "PROD_CERT_ID"),
+							"data.dnsimple_certificate.foobar", "certificate_id", os.Getenv("DNSIMPLE_CERTIFICATE_ID")),
 					),
 				},
 			},
@@ -36,5 +36,5 @@ func TestAccDNSimpleCertificateBasic(t *testing.T) {
 const testAccCheckDNSimpleCertificateConfigBasic = `
 data "dnsimple_certificate" "foobar" {
 	domain         = "%s"
-	certificate_id = "USE A CERTIFICATE IN PROD (ALSO DON'T FORGET TO CHANGE IT IN LINE26)"
+	certificate_id = %s
 }`

--- a/dnsimple/resource_dnsimple_lets_encrypt_certificate.go
+++ b/dnsimple/resource_dnsimple_lets_encrypt_certificate.go
@@ -32,8 +32,9 @@ func resourceDNSimpleLetsEncryptCertificate() *schema.Resource {
 				Optional: true,
 			},
 			"contact_id": {
-				Type:     schema.TypeInt,
-				Required: true,
+				Type:       schema.TypeInt,
+				Optional:   true,
+				Deprecated: "contact_id is deprecated and will be removed in the next major version.",
 			},
 			"name": {
 				Type:     schema.TypeString,
@@ -122,7 +123,6 @@ func resourceDNSimpleLetsEncryptCertificateCreate(ctx context.Context, data *sch
 	domainID := data.Get("domain_id").(string)
 
 	certificateAttributes := dnsimple.LetsencryptCertificateAttributes{
-		ContactID: int64(data.Get("contact_id").(int)),
 		AutoRenew: data.Get("auto_renew").(bool),
 		Name:      data.Get("name").(string),
 	}

--- a/dnsimple/resource_dnsimple_lets_encrypt_certificate.go
+++ b/dnsimple/resource_dnsimple_lets_encrypt_certificate.go
@@ -34,7 +34,7 @@ func resourceDNSimpleLetsEncryptCertificate() *schema.Resource {
 			"contact_id": {
 				Type:       schema.TypeInt,
 				Optional:   true,
-				Deprecated: "contact_id is deprecated and will be removed in the next major version.",
+				Deprecated: "contact_id is deprecated and has no effect. The attribute will be removed in the next major version.",
 			},
 			"name": {
 				Type:     schema.TypeString,

--- a/dnsimple/resource_dnsimple_lets_encrypt_certificate_test.go
+++ b/dnsimple/resource_dnsimple_lets_encrypt_certificate_test.go
@@ -8,8 +8,6 @@ import (
 	"testing"
 
 	"github.com/dnsimple/dnsimple-go/dnsimple"
-
-	_ "github.com/dnsimple/dnsimple-go/dnsimple"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )

--- a/dnsimple/resource_dnsimple_lets_encrypt_certificate_test.go
+++ b/dnsimple/resource_dnsimple_lets_encrypt_certificate_test.go
@@ -3,10 +3,11 @@ package dnsimple
 import (
 	"context"
 	"fmt"
-	"github.com/dnsimple/dnsimple-go/dnsimple"
 	"os"
 	"strconv"
 	"testing"
+
+	"github.com/dnsimple/dnsimple-go/dnsimple"
 
 	_ "github.com/dnsimple/dnsimple-go/dnsimple"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -18,13 +19,13 @@ func TestAccDNSimpleLetsEncryptCertificateCreate(t *testing.T) {
 
 	if sandbox == "false" {
 		var certificate dnsimple.Certificate
-		domain := "CHANGE ME TO THE ACTUAL DOMAIN ID"
+		domain := os.Getenv("DNSIMPLE_DOMAIN")
 		resource.Test(t, resource.TestCase{
 			PreCheck:          func() { testAccPreCheck(t) },
 			ProviderFactories: testAccProviderFactories,
 			Steps: []resource.TestStep{
 				{
-					Config: fmt.Sprintf(testAccLetsEncryptConfig, domain),
+					Config: fmt.Sprintf(testAccLetsEncryptConfig, domain, os.Getenv("DNSIMPLE_CERTIFICATE_NAME")),
 					Check: resource.ComposeTestCheckFunc(
 						testAccCheckLetsEncryptCertificate("dnsimple_lets_encrypt_certificate.foobar", &certificate)),
 				},
@@ -72,7 +73,7 @@ func testAccCheckLetsEncryptCertificate(resourceName string, certificate *dnsimp
 const testAccLetsEncryptConfig = `
 resource "dnsimple_lets_encrypt_certificate" "foobar" {
 	domain_id = "%s"
-	contact_id = "FIND YOUR CONTACT ID IN THE ADMIN"
+	contact_id = 1234
 	auto_renew = false
-	name = "www"
+	name = "%s"
 }`

--- a/docs/resources/lets_encrypt_certificate.md
+++ b/docs/resources/lets_encrypt_certificate.md
@@ -11,7 +11,6 @@ Provides a DNSimple Let's Encrypt certificate resource.
 ```hcl
 resource "dnsimple_lets_encrypt_certificate" "foobar" {
 	domain_id = "${var.dnsimple.domain_id}"
-	contact_id = "${var.dnsimple.contact_id}"
 	auto_renew = false
 	name = "www"
 }
@@ -22,7 +21,7 @@ resource "dnsimple_lets_encrypt_certificate" "foobar" {
 The following argument(s) are supported:
 
 * `domain_id` - (Required) The domain to be issued the certificate for
-* `contact_id` - (Required) The contact id for the certificate
+* `contact_id` - (Deprecated) The contact id for the certificate
 
 ## Attribute Reference
 


### PR DESCRIPTION
Around June 1 2022 we deprecated the use of the `contact_id` in our API when issuing certificates. The changes were made in dnsimple-go client and this PR ensures they are also reflected in the certificate resource.