### PR TITLE
Fix error while importing record with underscore

### DIFF
--- a/dnsimple/resource_dnsimple_zone_record.go
+++ b/dnsimple/resource_dnsimple_zone_record.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -246,10 +247,9 @@ func resourceDNSimpleZoneRecordDelete(ctx context.Context, data *schema.Resource
 }
 
 func resourceDNSimpleZoneRecordImport(ctx context.Context, data *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	parts := strings.Split(data.Id(), "_")
-
+	parts := importerSplitId(data.Id())
 	if len(parts) != 2 {
-		return nil, fmt.Errorf("error Importing dnsimple_zone_record. Please make sure the record ID is in the form DOMAIN_RECORDID (i.e. example.com_1234)")
+		return nil, fmt.Errorf("error importing dnsimple_zone_record. Please make sure the record ID is in the form ZONENAME_RECORDID (e.g. example.com_1234)")
 	}
 
 	data.SetId(parts[1])
@@ -259,4 +259,15 @@ func resourceDNSimpleZoneRecordImport(ctx context.Context, data *schema.Resource
 		return nil, fmt.Errorf(err[0].Summary)
 	}
 	return []*schema.ResourceData{data}, nil
+}
+
+func importerSplitId(s string) []string {
+	re := regexp.MustCompile(`(.+)_(\d+)`)
+	matches := re.FindAllStringSubmatch(s, -1)
+
+	if len(matches) == 1 {
+		return matches[0][1:]
+	}
+
+	return nil
 }

--- a/dnsimple/resource_dnsimple_zone_record_test.go
+++ b/dnsimple/resource_dnsimple_zone_record_test.go
@@ -8,11 +8,10 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/dnsimple/dnsimple-go/dnsimple"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestAccDNSimpleZoneRecord_Basic(t *testing.T) {
@@ -350,3 +349,11 @@ resource "dnsimple_zone_record" "foobar" {
 	ttl = 3600
 	priority = 10
 }`
+
+func TestImporterSplitId(t *testing.T) {
+	assert.Equal(t, []string{"example.com", "1234"}, importerSplitId("example.com_1234"))
+	assert.Equal(t, []string{"record.example.com", "1234"}, importerSplitId("record.example.com_1234"))
+	assert.Equal(t, []string{"_record.example.com", "1234"}, importerSplitId("_record.example.com_1234"))
+	assert.Nil(t, importerSplitId("_my_domain.example.com"))
+	assert.Nil(t, importerSplitId("_my_domain.example.com 1234"))
+}


### PR DESCRIPTION
Fixes #7

Note I have not modified the `dnsimple_record` resource, as it will be removed in the upcoming major version as per #63.
