### PR TITLE
Implement signature_algorithm parameter for Let's Encrypt resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## master
 
+* Added support for `signature_algorithm` attribute in the `dnsimple_lets_encrypt_certificate` resource.
+* Dependency updates.
+
 ## 0.15.0
 
 * Deprecate the use of `contact_id` in the `dnsimple_lets_encrypt_certificate` resource. The field is no longer in use and there is no replacement for it (dnsimple/terraform-provider-dnsimple#62)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,17 @@ Sideload the plugin
 
 ```shell
 make install
+# Replace `darwin_arm64` with your arch. GOBIN should be where the Go built binary is installed to.
+ln -s "$GOBIN/terraform-provider-dnsimple" "$HOME/.terraform.d/plugins/terraform.local/dnsimple/dnsimple/0.1.0/darwin_arm64/."
+```
+
+Use this as the provider configuration:
+
+```tf
+dnsimple = {
+  source  = "terraform.local/dnsimple/dnsimple"
+  version = "0.1.0"
+}
 ```
 
 You can use the `./example/simple.tf` config to test the provider.

--- a/dnsimple/resource_dnsimple_lets_encrypt_certificate.go
+++ b/dnsimple/resource_dnsimple_lets_encrypt_certificate.go
@@ -72,6 +72,10 @@ func resourceDNSimpleLetsEncryptCertificate() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"signature_algorithm": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 		},
 		Timeouts: &schema.ResourceTimeout{
 			Read: schema.DefaultTimeout(45 * time.Minute),
@@ -123,8 +127,9 @@ func resourceDNSimpleLetsEncryptCertificateCreate(ctx context.Context, data *sch
 	domainID := data.Get("domain_id").(string)
 
 	certificateAttributes := dnsimple.LetsencryptCertificateAttributes{
-		AutoRenew: data.Get("auto_renew").(bool),
-		Name:      data.Get("name").(string),
+		AutoRenew:          data.Get("auto_renew").(bool),
+		Name:               data.Get("name").(string),
+		SignatureAlgorithm: data.Get("signature_algorithm").(string),
 	}
 
 	response, err := provider.client.Certificates.PurchaseLetsencryptCertificate(ctx, provider.config.Account, domainID, certificateAttributes)

--- a/dnsimple/resource_dnsimple_lets_encrypt_certificate_test.go
+++ b/dnsimple/resource_dnsimple_lets_encrypt_certificate_test.go
@@ -74,4 +74,5 @@ resource "dnsimple_lets_encrypt_certificate" "foobar" {
 	contact_id = 1234
 	auto_renew = false
 	name = "%s"
+	signature_algorithm = "RSA"
 }`

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/terraform-providers/terraform-provider-dnsimple
 
 require (
-	github.com/dnsimple/dnsimple-go v1.0.1
+	github.com/dnsimple/dnsimple-go v1.1.0
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.17.0
 	github.com/stretchr/testify v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -35,6 +35,10 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dnsimple/dnsimple-go v1.0.1 h1:ueDji5xvz6+hLA4JPNvOXGYGHelex0TT7uXdN5ZEWnQ=
 github.com/dnsimple/dnsimple-go v1.0.1/go.mod h1:iw/53UDs5RV4ptHVyNrBBr7GHKnndETsP0J/n/JVnA4=
+github.com/dnsimple/dnsimple-go v1.0.2-0.20230224085626-b6310a700790 h1:WqBgVgSDxROKWnK8IX3ewexCSvdUS88hv1cWJdIBpyI=
+github.com/dnsimple/dnsimple-go v1.0.2-0.20230224085626-b6310a700790/go.mod h1:iw/53UDs5RV4ptHVyNrBBr7GHKnndETsP0J/n/JVnA4=
+github.com/dnsimple/dnsimple-go v1.1.0 h1:9J8fiVjLEkiKBn37vL5Azi/cC9d9ww3e9xB6XrNJmd8=
+github.com/dnsimple/dnsimple-go v1.1.0/go.mod h1:iw/53UDs5RV4ptHVyNrBBr7GHKnndETsP0J/n/JVnA4=
 github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=

--- a/go.sum
+++ b/go.sum
@@ -33,10 +33,6 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dnsimple/dnsimple-go v1.0.1 h1:ueDji5xvz6+hLA4JPNvOXGYGHelex0TT7uXdN5ZEWnQ=
-github.com/dnsimple/dnsimple-go v1.0.1/go.mod h1:iw/53UDs5RV4ptHVyNrBBr7GHKnndETsP0J/n/JVnA4=
-github.com/dnsimple/dnsimple-go v1.0.2-0.20230224085626-b6310a700790 h1:WqBgVgSDxROKWnK8IX3ewexCSvdUS88hv1cWJdIBpyI=
-github.com/dnsimple/dnsimple-go v1.0.2-0.20230224085626-b6310a700790/go.mod h1:iw/53UDs5RV4ptHVyNrBBr7GHKnndETsP0J/n/JVnA4=
 github.com/dnsimple/dnsimple-go v1.1.0 h1:9J8fiVjLEkiKBn37vL5Azi/cC9d9ww3e9xB6XrNJmd8=
 github.com/dnsimple/dnsimple-go v1.1.0/go.mod h1:iw/53UDs5RV4ptHVyNrBBr7GHKnndETsP0J/n/JVnA4=
 github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=


### PR DESCRIPTION
Add the `signature_algorithm` attribute for the `dnsimple_lets_encrypt_certificate` resource.