### PR TITLE
Correctly match RRs in the prefetch cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master
 
+BUG FIXES:
+
+* Prefetch cache lookups are deterministic (dnsimple/terraform-provider-dnsimple#84)
+
 ## 0.16.1
 
 IMPROVEMENTS:

--- a/dnsimple/resource_dnsimple_zone_record.go
+++ b/dnsimple/resource_dnsimple_zone_record.go
@@ -150,7 +150,7 @@ func resourceDNSimpleZoneRecordRead(ctx context.Context, data *schema.ResourceDa
 		}
 
 		for index := range records {
-			if records[index].Name == data.Get("name").(string) {
+			if records[index].Name == data.Get("name").(string) && records[index].Type == data.Get("type").(string) && records[index].Content == data.Get("value").(string) {
 				record = &records[index]
 				break
 			}


### PR DESCRIPTION
It was found that the **prefetch** feature. Which pulls the entire zone and creates a local cache for the provider to use and determine if a record already exists as a performance improvement and a way to reduce the number of API requests. The lookup algorithm did a naive lookup only based on the name of the Resource Record (RR), however, that can yield false positives and also result in incorrect records being created/updated.

### Implementation notes

Unfortunately, the current version of the TF SDK does not support testing of for_each resources. The algorithm was updated to match all attributes that make a resource unique which are `name`, `type`, and `content`. There is also the potential of using the record ids to match existing records but the current implementation allows for some flexibility when using the provider especially since we do not support duplicate records.

Belongs to https://github.com/dnsimple/terraform-provider-dnsimple/issues/80