### PR TITLE
Fix `dnsimple_zone_record` import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master
 
+BUG FIXES:
+
+* Correctly error out and terminate `dnsimple_zone_record` import operations when invalid (dnsimple/terraform-provider-dnsimple#88)
+
 ## 0.16.2
 
 BUG FIXES:


### PR DESCRIPTION
As pointed out in #27 our import functionality was creating an empty resource record. The behavior is not compliant with the terraform provider SDK, and also as a user, it would be best if we supply a direct error message when an import fails with the reason for the failure.

This PR refactors the import function to attempt to find the zone record without relying on the `resourceDNSimpleZoneRecordRead` function which has the additional functionality of lookup the prefetch cache. It also directly handles errors and passes them to the user.

**Before**
```
terraform import dnsimple_zone_record.makednshappen_eu_ns1 makednshappen.eu_29676799
dnsimple_zone_record.makednshappen_eu_ns1: Importing from ID "makednshappen.eu_29676799"...
╷
│ Error: The provider returned a resource missing an identifier during ImportResourceState. This is generally a bug in the resource implementation for import. Resource import code should not call d.SetId("") or create an empty ResourceData. If the resource is missing, instead return an error. Please report this to the provider developers.
│
│
╵
```

**After**
```
terraform import dnsimple_zone_record.makednshappen_eu_ns1 makednshappen.eu_29676799
dnsimple_zone_record.makednshappen_eu_ns1: Importing from ID "makednshappen.eu_29676799"...
╷
│ Error: GET https://api.sandbox.dnsimple.com/v2/1234/zones/makednshappen.eu/records/29676799: 404 Record `29676799` not found
│
│
╵
```