### PR TITLE
Implement `dnsimple_domain_delegation` resource

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -65,13 +65,13 @@ jobs:
           - '1.2.*'
         include:
           - terraform: '0.15.*'
-            domain: 'dnsimple-015.terraform'
+            domain: 'dnsimple-0-15-terraform.com '
           - terraform: '1.0.*'
-            domain: 'dnsimple-10.terraform'
+            domain: 'dnsimple-1-0-terraform.com'
           - terraform: '1.1.*'
-            domain: 'dnsimple-11.terraform'
+            domain: 'dnsimple-1-1-terraform.com'
           - terraform: '1.2.*'
-            domain: 'dnsimple-12.terraform'
+            domain: 'dnsimple-1-2-terraform.com'
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -65,7 +65,7 @@ jobs:
           - '1.2.*'
         include:
           - terraform: '0.15.*'
-            domain: 'dnsimple-0-15-terraform.com '
+            domain: 'dnsimple-0-15-terraform.com'
           - terraform: '1.0.*'
             domain: 'dnsimple-1-0-terraform.com'
           - terraform: '1.1.*'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -65,13 +65,13 @@ jobs:
           - '1.2.*'
         include:
           - terraform: '0.15.*'
-            domain: 'dnsimple-0-15-terraform.com'
+            domain: 'dnsimple-0-15-terraform.bio'
           - terraform: '1.0.*'
-            domain: 'dnsimple-1-0-terraform.com'
+            domain: 'dnsimple-1-0-terraform.bio'
           - terraform: '1.1.*'
-            domain: 'dnsimple-1-1-terraform.com'
+            domain: 'dnsimple-1-1-terraform.bio'
           - terraform: '1.2.*'
-            domain: 'dnsimple-1-2-terraform.com'
+            domain: 'dnsimple-1-2-terraform.bio'
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -5,7 +5,7 @@ HOSTNAME     = registry.terraform.io
 NAMESPACE    = dnsimple
 BINARY       = terraform-provider-${PKG_NAME}
 VERSION      = $(shell git describe --tags --always | cut -c 2-)
-OS_ARCH      := $(shell echo "$$(uname -s)_$$(go env GOARCH)" | tr A-Z a-z)
+OS_ARCH      = darwin_$(shell uname -m)
 
 default: build
 
@@ -13,9 +13,8 @@ build: fmtcheck
 	go install
 
 install: build
-# VERSION contains the Git commit, which is not a valid version for Terraform. We also use 0.0.1 so that the version never conflicts with versions from the registry, and also so it's easy to see when a local override is being used.
-	mkdir -p ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${PKG_NAME}/0.0.1/${OS_ARCH}
-	mv ${GOPATH}/bin/${BINARY} ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${PKG_NAME}/0.0.1/${OS_ARCH}
+	mkdir -p ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${PKG_NAME}/${VERSION}/${OS_ARCH}
+	mv ${GOPATH}/bin/${BINARY} ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${PKG_NAME}/${VERSION}/${OS_ARCH}
 
 test: fmtcheck
 	go test $(TEST) $(TESTARGS) -timeout=5m

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -5,7 +5,7 @@ HOSTNAME     = registry.terraform.io
 NAMESPACE    = dnsimple
 BINARY       = terraform-provider-${PKG_NAME}
 VERSION      = $(shell git describe --tags --always | cut -c 2-)
-OS_ARCH      = darwin_$(shell uname -m)
+OS_ARCH      := $(shell echo "$$(uname -s)_$$(go env GOARCH)" | tr A-Z a-z)
 
 default: build
 
@@ -13,8 +13,9 @@ build: fmtcheck
 	go install
 
 install: build
-	mkdir -p ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${PKG_NAME}/${VERSION}/${OS_ARCH}
-	mv ${GOPATH}/bin/${BINARY} ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${PKG_NAME}/${VERSION}/${OS_ARCH}
+# VERSION contains the Git commit, which is not a valid version for Terraform. We also use 0.0.1 so that the version never conflicts with versions from the registry, and also so it's easy to see when a local override is being used.
+	mkdir -p ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${PKG_NAME}/0.0.1/${OS_ARCH}
+	mv ${GOPATH}/bin/${BINARY} ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${PKG_NAME}/0.0.1/${OS_ARCH}
 
 test: fmtcheck
 	go test $(TEST) $(TESTARGS) -timeout=5m

--- a/docs/resources/domain_delegation.md
+++ b/docs/resources/domain_delegation.md
@@ -17,7 +17,7 @@ This resource allows you to control the delegation records (name servers) for a 
 # Create a domain delegation
 resource "dnsimple_domain_delegation" "foobar" {
   id = "${var.dnsimple.domain}"
-  name_servers = ["example.org", "example.com"]
+  name_servers = ["ns1.example.org", "ns2.example.com"]
 }
 ```
 

--- a/docs/resources/domain_delegation.md
+++ b/docs/resources/domain_delegation.md
@@ -25,12 +25,12 @@ resource "dnsimple_domain_delegation" "foobar" {
 
 The following argument(s) are supported:
 
-* `id` - (Required) The domain ID.
+* `domain` - (Required) The domain ID or name.
 * `name_servers` - (Required) The list of name servers to delegate to.
 
 # Attributes Reference
 
-There are no additional attributes.
+* `id` - The domain ID or name.
 
 ## Import
 

--- a/docs/resources/domain_delegation.md
+++ b/docs/resources/domain_delegation.md
@@ -1,0 +1,38 @@
+---
+page_title: "DNSimple: dnsimple_domain_delegation"
+---
+
+# dnsimple\_domain\_delegation
+
+Provides a DNSimple domain delegation resource.
+
+This resource works differently to other resources. It does not create a new resource, but instead updates the existing domain delegation. This is because the domain delegation is a property of the domain, not a separate resource. When this resource is destroyed, only the Terraform state is removed; the domain delegation is left intact and unmanaged by Terraform.
+
+## Example Usage
+
+```hcl
+# Create a domain delegation
+resource "dnsimple_domain_delegation" "foobar" {
+  id = "${var.dnsimple.domain}"
+  name_servers = ["example.org", "example.com"]
+}
+```
+
+## Argument Reference
+
+The following argument(s) are supported:
+
+* `id` - (Required) The domain ID.
+* `name_servers` - (Required) The list of name servers to delegate to.
+
+# Attributes Reference
+
+There are no additional attributes.
+
+## Import
+
+DNSimple domain delegations can be imported.
+
+```bash
+terraform import dnsimple_domain.resource_name domain_id
+```

--- a/docs/resources/domain_delegation.md
+++ b/docs/resources/domain_delegation.md
@@ -6,7 +6,10 @@ page_title: "DNSimple: dnsimple_domain_delegation"
 
 Provides a DNSimple domain delegation resource.
 
-This resource works differently to other resources. It does not create a new resource, but instead updates the existing domain delegation. This is because the domain delegation is a property of the domain, not a separate resource. When this resource is destroyed, only the Terraform state is removed; the domain delegation is left intact and unmanaged by Terraform.
+This resource allows you to control the delegation records (name servers) for a domain.
+
+~> **Note:** This resource currently only supports the management of domains that are registered with DNSimple.
+-> **Note:** When this resource is destroyed, only the Terraform state is removed; the domain delegation is left intact and unmanaged by Terraform.
 
 ## Example Usage
 

--- a/internal/framework/provider/provider.go
+++ b/internal/framework/provider/provider.go
@@ -167,6 +167,7 @@ func (p *DnsimpleProvider) Configure(ctx context.Context, req provider.Configure
 
 func (p *DnsimpleProvider) Resources(ctx context.Context) []func() resource.Resource {
 	return []func() resource.Resource{
+		resources.NewDomainDelegationResource,
 		resources.NewDomainResource,
 		resources.NewEmailForwardResource,
 		resources.NewLetsEncryptCertificateResource,

--- a/internal/framework/resources/contact_resource.go
+++ b/internal/framework/resources/contact_resource.go
@@ -224,6 +224,7 @@ func (r *ContactResource) Read(ctx context.Context, req resource.ReadRequest, re
 			fmt.Sprintf("failed to read DNSimple Contact: %d", data.Id.ValueInt64()),
 			err.Error(),
 		)
+		return
 	}
 
 	r.updateModelFromAPIResponse(response.Data, data)
@@ -308,6 +309,7 @@ func (r *ContactResource) Delete(ctx context.Context, req resource.DeleteRequest
 			fmt.Sprintf("failed to delete DNSimple Contact: %d", data.Id.ValueInt64()),
 			err.Error(),
 		)
+		return
 	}
 }
 
@@ -315,6 +317,7 @@ func (r *ContactResource) ImportState(ctx context.Context, req resource.ImportSt
 	id, err := strconv.ParseInt(req.ID, 10, 64)
 	if err != nil {
 		resp.Diagnostics.AddError("resource import invalid ID", fmt.Sprintf("failed to parse contact ID (%s) as integer", req.ID))
+		return
 	}
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), id)...)
 }

--- a/internal/framework/resources/domain_delegation_resource.go
+++ b/internal/framework/resources/domain_delegation_resource.go
@@ -186,7 +186,6 @@ func (r *DomainDelegationResource) ImportState(ctx context.Context, req resource
 		)
 	}
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), domainId)...)
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("name_servers"), response.Data)...)
 }
 
 func (r *DomainDelegationResource) updateModelFromAPIResponse(ctx context.Context, delegation *dnsimple.Delegation, data *DomainDelegationResourceModel) diag.Diagnostics {

--- a/internal/framework/resources/domain_delegation_resource.go
+++ b/internal/framework/resources/domain_delegation_resource.go
@@ -141,6 +141,7 @@ func (r *DomainDelegationResource) Read(ctx context.Context, req resource.ReadRe
 			fmt.Sprintf("failed to read domain delegation for domain %s", data.Domain.ValueString()),
 			err.Error(),
 		)
+		return
 	}
 
 	resp.Diagnostics.Append(r.updateModelFromAPIResponse(ctx, response.Data, data)...)
@@ -168,6 +169,7 @@ func (r *DomainDelegationResource) Update(ctx context.Context, req resource.Upda
 			fmt.Sprintf("failed to update domain delegation for domain %s", data.Domain.ValueString()),
 			err.Error(),
 		)
+		return
 	}
 
 	resp.Diagnostics.Append(r.updateModelFromAPIResponse(ctx, response.Data, data)...)
@@ -188,6 +190,7 @@ func (r *DomainDelegationResource) ImportState(ctx context.Context, req resource
 			fmt.Sprintf("failed to fetch domain delegation for domain %s", domainId),
 			err.Error(),
 		)
+		return
 	}
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), domainId)...)
 }

--- a/internal/framework/resources/domain_delegation_resource.go
+++ b/internal/framework/resources/domain_delegation_resource.go
@@ -184,15 +184,8 @@ func (r *DomainDelegationResource) Delete(ctx context.Context, req resource.Dele
 
 func (r *DomainDelegationResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	domainId := req.ID
-	_, err := r.config.Client.Registrar.GetDomainDelegation(ctx, r.config.AccountID, domainId)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			fmt.Sprintf("failed to fetch domain delegation for domain %s", domainId),
-			err.Error(),
-		)
-		return
-	}
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), domainId)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("domain"), domainId)...)
 }
 
 func (r *DomainDelegationResource) updateModelFromAPIResponse(ctx context.Context, delegation *dnsimple.Delegation, data *DomainDelegationResourceModel) diag.Diagnostics {

--- a/internal/framework/resources/domain_delegation_resource.go
+++ b/internal/framework/resources/domain_delegation_resource.go
@@ -1,0 +1,196 @@
+package resources
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/dnsimple/dnsimple-go/dnsimple"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/terraform-providers/terraform-provider-dnsimple/internal/framework/common"
+)
+
+// Ensure the implementation satisfies the expected interfaces.
+var (
+	_ resource.Resource                = &DomainDelegationResource{}
+	_ resource.ResourceWithConfigure   = &DomainDelegationResource{}
+	_ resource.ResourceWithImportState = &DomainDelegationResource{}
+)
+
+func NewDomainDelegationResource() resource.Resource {
+	return &DomainDelegationResource{}
+}
+
+// DomainDelegationResource defines the resource implementation.
+type DomainDelegationResource struct {
+	config *common.DnsimpleProviderConfig
+}
+
+// DomainDelegationResourceModel describes the resource data model.
+type DomainDelegationResourceModel struct {
+	Id          types.String `tfsdk:"id"`
+	NameServers types.List   `tfsdk:"name_servers"`
+}
+
+func (r *DomainDelegationResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_domain_delegation"
+}
+
+func (r *DomainDelegationResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		// This description is used by the documentation generator and the language server.
+		MarkdownDescription: "DNSimple domain delegation resource",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"name_servers": schema.ListAttribute{
+				Required:    true,
+				ElementType: types.StringType,
+				PlanModifiers: []planmodifier.List{
+					listplanmodifier.RequiresReplace(),
+				},
+			},
+		},
+	}
+}
+
+func (r *DomainDelegationResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	// Prevent panic if the provider has not been configured.
+	if req.ProviderData == nil {
+		return
+	}
+
+	config, ok := req.ProviderData.(*common.DnsimpleProviderConfig)
+
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *provider.DnsimpleProviderConfig, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+
+		return
+	}
+
+	r.config = config
+}
+
+func (r *DomainDelegationResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data *DomainDelegationResourceModel
+
+	// Read Terraform plan data into the model
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	nameServers := dnsimple.Delegation{}
+	resp.Diagnostics.Append(data.NameServers.ElementsAs(ctx, &nameServers, false)...)
+
+	tflog.Debug(ctx, "creating domain delegation", map[string]interface{}{"name servers": nameServers})
+
+	_, err := r.config.Client.Registrar.ChangeDomainDelegation(ctx, r.config.AccountID, data.Id.ValueString(), &nameServers)
+
+	if err != nil {
+		var errorResponse *dnsimple.ErrorResponse
+		if errors.As(err, &errorResponse) {
+			resp.Diagnostics.Append(attributeErrorsToDiagnostics(errorResponse)...)
+			return
+		}
+
+		resp.Diagnostics.AddError(
+			"failed to create domain delegation",
+			err.Error(),
+		)
+		return
+	}
+
+	tflog.Info(ctx, "created domain delegation", map[string]interface{}{"domain": data.Id})
+
+	// Save data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *DomainDelegationResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	// Read Terraform prior state data into the model.
+	var data *DomainDelegationResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	response, err := r.config.Client.Registrar.GetDomainDelegation(ctx, r.config.AccountID, data.Id.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("failed to read domain delegation for domain %s", data.Id.ValueString()),
+			err.Error(),
+		)
+	}
+
+	resp.Diagnostics.Append(r.updateModelFromAPIResponse(ctx, response.Data, data)...)
+
+	// Save updated data into Terraform state.
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *DomainDelegationResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data *DomainDelegationResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	nameServers := dnsimple.Delegation{}
+	resp.Diagnostics.Append(data.NameServers.ElementsAs(ctx, &nameServers, false)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	response, err := r.config.Client.Registrar.ChangeDomainDelegation(ctx, r.config.AccountID, data.Id.ValueString(), &nameServers)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("failed to update domain delegation for domain %s", data.Id.ValueString()),
+			err.Error(),
+		)
+	}
+
+	resp.Diagnostics.Append(r.updateModelFromAPIResponse(ctx, response.Data, data)...)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *DomainDelegationResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	// No-op
+	tflog.Info(ctx, "deleting a domain delegation simply deletes the Terraform state, and the current domain delegation will remain as is and no longer be managed by Terraform")
+}
+
+func (r *DomainDelegationResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	domainId := req.ID
+	response, err := r.config.Client.Registrar.GetDomainDelegation(ctx, r.config.AccountID, domainId)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("failed to fetch domain delegation for domain %s", domainId),
+			err.Error(),
+		)
+	}
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), domainId)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("name_servers"), response.Data)...)
+}
+
+func (r *DomainDelegationResource) updateModelFromAPIResponse(ctx context.Context, delegation *dnsimple.Delegation, data *DomainDelegationResourceModel) diag.Diagnostics {
+	nameServers, diag := types.ListValueFrom(ctx, types.StringType, delegation)
+	data.NameServers = nameServers
+	return diag
+}

--- a/internal/framework/resources/domain_delegation_resource_test.go
+++ b/internal/framework/resources/domain_delegation_resource_test.go
@@ -28,6 +28,7 @@ func TestAccDomainDelegationResource(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name_servers.0", "ns-998.awsdns-60.net"),
 					resource.TestCheckResourceAttr(resourceName, "name_servers.1", "ns-1556.awsdns-02.co.uk"),
 				),
+			},
 			{
 				ResourceName:      resourceName,
 				ImportStateIdFunc: testAccDomainDelegationImportStateIDFunc(resourceName),

--- a/internal/framework/resources/domain_delegation_resource_test.go
+++ b/internal/framework/resources/domain_delegation_resource_test.go
@@ -1,0 +1,69 @@
+package resources_test
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	_ "github.com/terraform-providers/terraform-provider-dnsimple/internal/framework/resources"
+)
+
+func TestAccDomainDelegationResource(t *testing.T) {
+	domainId := os.Getenv("DNSIMPLE_DOMAIN")
+	resourceName := "dnsimple_domain_delegation.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckDomainDelegationResourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDomainDelegationResourceConfig(domainId),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", domainId),
+					resource.TestCheckResourceAttr(resourceName, "name_servers.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "name_servers.0", "example.com"),
+					resource.TestCheckResourceAttr(resourceName, "name_servers.1", "example.org"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccDomainDelegationImportStateIDFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+
+// Deleting simply reliquishes control from Terraform and leaves server state intact.
+func testAccCheckDomainDelegationResourceDestroy(state *terraform.State) error {
+	return nil
+}
+
+func testAccDomainDelegationImportStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("Resource not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return "", errors.New("No resource ID set")
+		}
+
+		return rs.Primary.ID, nil
+	}
+}
+
+func testAccDomainDelegationResourceConfig(domainId string) string {
+	return fmt.Sprintf(`
+resource "dnsimple_domain_delegation" "test" {
+	id = %[1]q
+	name_servers = ["example.com", "example.org"]
+}`, domainId)
+}

--- a/internal/framework/resources/domain_delegation_resource_test.go
+++ b/internal/framework/resources/domain_delegation_resource_test.go
@@ -25,10 +25,9 @@ func TestAccDomainDelegationResource(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "id", domainId),
 					resource.TestCheckResourceAttr(resourceName, "name_servers.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "name_servers.0", "example.com"),
-					resource.TestCheckResourceAttr(resourceName, "name_servers.1", "example.org"),
+					resource.TestCheckResourceAttr(resourceName, "name_servers.0", "ns-998.awsdns-60.net"),
+					resource.TestCheckResourceAttr(resourceName, "name_servers.1", "ns-1556.awsdns-02.co.uk"),
 				),
-			},
 			{
 				ResourceName:      resourceName,
 				ImportStateIdFunc: testAccDomainDelegationImportStateIDFunc(resourceName),

--- a/internal/framework/resources/domain_delegation_resource_test.go
+++ b/internal/framework/resources/domain_delegation_resource_test.go
@@ -23,7 +23,8 @@ func TestAccDomainDelegationResource(t *testing.T) {
 			{
 				Config: testAccDomainDelegationResourceConfig(domainId),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "id", domainId),
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "domain", domainId),
 					resource.TestCheckResourceAttr(resourceName, "name_servers.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "name_servers.0", "ns-998.awsdns-60.net"),
 					resource.TestCheckResourceAttr(resourceName, "name_servers.1", "ns-1556.awsdns-02.co.uk"),

--- a/internal/framework/resources/domain_delegation_resource_test.go
+++ b/internal/framework/resources/domain_delegation_resource_test.go
@@ -64,7 +64,7 @@ func testAccDomainDelegationImportStateIDFunc(resourceName string) resource.Impo
 func testAccDomainDelegationResourceConfig(domainId string) string {
 	return fmt.Sprintf(`
 resource "dnsimple_domain_delegation" "test" {
-	id = %[1]q
+	domain = %[1]q
 	name_servers = ["ns-998.awsdns-60.net", "ns-1556.awsdns-02.co.uk"]
 }`, domainId)
 }

--- a/internal/framework/resources/domain_delegation_resource_test.go
+++ b/internal/framework/resources/domain_delegation_resource_test.go
@@ -63,6 +63,6 @@ func testAccDomainDelegationResourceConfig(domainId string) string {
 	return fmt.Sprintf(`
 resource "dnsimple_domain_delegation" "test" {
 	id = %[1]q
-	name_servers = ["example.com", "example.org"]
+	name_servers = ["ns-998.awsdns-60.net", "ns-1556.awsdns-02.co.uk"]
 }`, domainId)
 }

--- a/internal/framework/resources/domain_resource.go
+++ b/internal/framework/resources/domain_resource.go
@@ -157,6 +157,7 @@ func (r *DomainResource) Read(ctx context.Context, req resource.ReadRequest, res
 			fmt.Sprintf("failed to read DNSimple Domain: %s", data.Name.ValueString()),
 			err.Error(),
 		)
+		return
 	}
 
 	r.updateModelFromAPIResponse(response.Data, data)
@@ -188,6 +189,7 @@ func (r *DomainResource) Delete(ctx context.Context, req resource.DeleteRequest,
 			fmt.Sprintf("failed to delete DNSimple Domain: %s", data.Name.ValueString()),
 			err.Error(),
 		)
+		return
 	}
 }
 
@@ -199,6 +201,7 @@ func (r *DomainResource) ImportState(ctx context.Context, req resource.ImportSta
 			fmt.Sprintf("failed to find DNSimple Domain ID: %s", req.ID),
 			err.Error(),
 		)
+		return
 	}
 
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), response.Data.ID)...)

--- a/internal/framework/resources/email_forward_resource.go
+++ b/internal/framework/resources/email_forward_resource.go
@@ -156,6 +156,7 @@ func (r *EmailForwardResource) Read(ctx context.Context, req resource.ReadReques
 			fmt.Sprintf("failed to read DNSimple EmailForward: %d", data.Id.ValueInt64()),
 			err.Error(),
 		)
+		return
 	}
 
 	r.updateModelFromAPIResponse(response.Data, data)
@@ -188,6 +189,7 @@ func (r *EmailForwardResource) Delete(ctx context.Context, req resource.DeleteRe
 			fmt.Sprintf("failed to delete DNSimple EmailForward: %d", data.Id.ValueInt64()),
 			err.Error(),
 		)
+		return
 	}
 }
 
@@ -195,6 +197,7 @@ func (r *EmailForwardResource) ImportState(ctx context.Context, req resource.Imp
 	parts := strings.Split(req.ID, "_")
 	if len(parts) != 2 {
 		resp.Diagnostics.AddError("resource import invalid ID", fmt.Sprintf("wrong format of import ID (%s), use: '<domain-name>_<email-forward-id>'", req.ID))
+		return
 	}
 	domainName := parts[0]
 	recordID := parts[1]
@@ -202,6 +205,7 @@ func (r *EmailForwardResource) ImportState(ctx context.Context, req resource.Imp
 	id, err := strconv.ParseInt(recordID, 10, 64)
 	if err != nil {
 		resp.Diagnostics.AddError("resource import invalid ID", fmt.Sprintf("failed to parse email forward ID (%s) as integer", recordID))
+		return
 	}
 
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), id)...)

--- a/internal/framework/resources/lets_encrypt_certificate_resource.go
+++ b/internal/framework/resources/lets_encrypt_certificate_resource.go
@@ -216,6 +216,7 @@ func (r *LetsEncryptCertificateResource) Read(ctx context.Context, req resource.
 			fmt.Sprintf("failed to read DNSimple LetsEncryptCertificate: %d", data.Id.ValueInt64()),
 			err.Error(),
 		)
+		return
 	}
 
 	r.updateModelFromAPIResponse(response.Data, data)

--- a/internal/framework/resources/zone_record_resource.go
+++ b/internal/framework/resources/zone_record_resource.go
@@ -313,6 +313,7 @@ func (r *ZoneRecordResource) Delete(ctx context.Context, req resource.DeleteRequ
 			fmt.Sprintf("failed to delete DNSimple Record: %s", data.Name.ValueString()),
 			err.Error(),
 		)
+		return
 	}
 }
 
@@ -320,6 +321,7 @@ func (r *ZoneRecordResource) ImportState(ctx context.Context, req resource.Impor
 	parts := strings.Split(req.ID, "_")
 	if len(parts) != 2 {
 		resp.Diagnostics.AddError("resource import invalid ID", fmt.Sprintf("wrong format of import ID (%s), use: '<zone-name>_<record-id>'", req.ID))
+		return
 	}
 	zoneName := parts[0]
 	recordID := parts[1]
@@ -327,6 +329,7 @@ func (r *ZoneRecordResource) ImportState(ctx context.Context, req resource.Impor
 	id, err := strconv.ParseInt(recordID, 10, 64)
 	if err != nil {
 		resp.Diagnostics.AddError("resource import invalid ID", fmt.Sprintf("failed to parse record ID (%s) as integer", recordID))
+		return
 	}
 
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), id)...)


### PR DESCRIPTION
This creates a resource that will take control of a domain's delegation settings and allow management via Terraform. When the resource is destroyed, only the Terraform state is removed; the domain delegation is kept as is and will no longer be managed by Terraform.