### PR TITLE
Import dnsimple_registered_domain with domain name only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## main
 
+IMPROVEMENTS:
+
+- `dnsimple_registered_domain`: Support resource importing with domain name only (dnsimple/terraform-provider-dnsimple#107)
+
+NOTES:
+
+Prior to this release the `dnsimple_registered_domain` resource could only be imported using the domain name and the domain registration ID. This release adds support for importing the resource using the domain name only. This has no effects on existing resources.
+
 ## 1.1.0
 
 FEATURES:

--- a/docs/resources/domain_delegation.md
+++ b/docs/resources/domain_delegation.md
@@ -17,7 +17,7 @@ This resource allows you to control the delegation records (name servers) for a 
 ```hcl
 # Create a domain delegation
 resource "dnsimple_domain_delegation" "foobar" {
-  id = "${var.dnsimple.domain}"
+  domain = "${var.dnsimple.domain}"
   name_servers = ["ns1.example.org", "ns2.example.com"]
 }
 ```
@@ -26,17 +26,19 @@ resource "dnsimple_domain_delegation" "foobar" {
 
 The following argument(s) are supported:
 
-* `domain` - (Required) The domain ID or name.
+* `domain` - (Required) The domain name.
 * `name_servers` - (Required) The list of name servers to delegate to.
 
 # Attributes Reference
 
-* `id` - The domain ID or name.
+* `id` - The domain name.
 
 ## Import
 
-DNSimple domain delegations can be imported.
+DNSimple domain delegations can be imported using the domain name.
+
+**Importing domain delegation for example.com**
 
 ```bash
-terraform import dnsimple_domain.resource_name domain_id
+terraform import dnsimple_domain_delegation.resource_name example.com
 ```

--- a/docs/resources/registered_domain.md
+++ b/docs/resources/registered_domain.md
@@ -81,7 +81,13 @@ Attributes Reference:
 
 ## Import
 
-DNSimple registered domains can be imported using their domain name and domain registration ID.
+DNSimple registered domains can be imported using their domain name and **optionally** with domain registration ID.
+
+**Importing registered domain example.com**
+
+```bash
+terraform import dnsimple_registered_domain.resource_name example.com
+```
 
 **Importing registered domain example.com with domain registration ID 1234**
 
@@ -89,4 +95,4 @@ DNSimple registered domains can be imported using their domain name and domain r
 terraform import dnsimple_registered_domain.resource_name example.com_1234
 ```
 
-~> **Note:** At present there is no way to retrieve the domain registration ID from the DNSimple API or UI. You will need to have noted the ID when you created the domain registration. While we work on a solution to this, you can reach out to our support team and we will be happy to help.
+~> **Note:** At present there is no way to retrieve the domain registration ID from the DNSimple API or UI. You will need to have noted the ID when you created the domain registration. Prefer using the domain name only when importing.

--- a/docs/resources/zone_record.md
+++ b/docs/resources/zone_record.md
@@ -34,7 +34,7 @@ resource "dnsimple_zone_record" "foobar" {
 
 The following arguments are supported:
 
-* `zone_name` - (Required) The domain to add the record to
+* `zone_name` - (Required) The zone name to add the record to
 * `name` - (Required) The name of the record
 * `value` - (Required) The value of the record
 * `type` - (Required) The type of the record
@@ -45,7 +45,7 @@ The following arguments are supported:
 ## Attributes Reference
 
 * `id` - The record ID
-* `zone_id` - The domain ID of the record
+* `zone_id` - The zone ID of the record
 * `qualified_name` - The FQDN of the record
 
 ## Import

--- a/internal/framework/resources/domain_ds_record_resource.go
+++ b/internal/framework/resources/domain_ds_record_resource.go
@@ -181,6 +181,7 @@ func (r *DsRecordResource) Read(ctx context.Context, req resource.ReadRequest, r
 			fmt.Sprintf("failed to read DNSimple domain delegation signer record: %d", data.Id.ValueInt64()),
 			err.Error(),
 		)
+		return
 	}
 
 	r.updateModelFromAPIResponse(response.Data, data)

--- a/internal/framework/resources/registered_domain/common.go
+++ b/internal/framework/resources/registered_domain/common.go
@@ -104,13 +104,15 @@ func (r *RegisteredDomainResource) setDNSSEC(ctx context.Context, data *Register
 }
 
 func (r *RegisteredDomainResource) updateModelFromAPIResponse(ctx context.Context, data *RegisteredDomainResourceModel, domainRegistration *dnsimple.DomainRegistration, domain *dnsimple.Domain, dnssec *dnsimple.Dnssec) diag.Diagnostics {
-	domainRegistrationObject, diags := r.domainRegistrationAPIResponseToObject(ctx, domainRegistration)
+	if domainRegistration != nil {
+		domainRegistrationObject, diags := r.domainRegistrationAPIResponseToObject(ctx, domainRegistration)
 
-	if diags.HasError() {
-		return diags
+		if diags.HasError() {
+			return diags
+		}
+
+		data.DomainRegistration = domainRegistrationObject
 	}
-
-	data.DomainRegistration = domainRegistrationObject
 
 	if domain != nil {
 		data.Id = types.Int64Value(domain.ID)

--- a/internal/framework/resources/registered_domain/import.go
+++ b/internal/framework/resources/registered_domain/import.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/terraform-providers/terraform-provider-dnsimple/internal/consts"
 	"github.com/terraform-providers/terraform-provider-dnsimple/internal/framework/common"
 )
 
@@ -39,6 +40,14 @@ func (r *RegisteredDomainResource) ImportState(ctx context.Context, req resource
 		resp.Diagnostics.AddError(
 			fmt.Sprintf("unexpected error when trying to find DNSimple Domain ID: %s", domainName),
 			err.Error(),
+		)
+		return
+	}
+
+	if domainResponse.Data.State != consts.DomainStateRegistered {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("domain %s is not registered", domainName),
+			"domain must be registered before it can be imported",
 		)
 		return
 	}

--- a/internal/framework/resources/registered_domain/import.go
+++ b/internal/framework/resources/registered_domain/import.go
@@ -16,7 +16,8 @@ func (r *RegisteredDomainResource) ImportState(ctx context.Context, req resource
 	parts := strings.Split(req.ID, "_")
 	domainName := parts[0]
 
-	if len(parts) == 2 {
+	usingDomainAndRegistrationID := len(parts) == 2
+	if usingDomainAndRegistrationID {
 		domainRegistrationID := parts[1]
 
 		domainRegistrationResponse, err := r.config.Client.Registrar.GetDomainRegistration(ctx, r.config.AccountID, domainName, domainRegistrationID)
@@ -44,7 +45,7 @@ func (r *RegisteredDomainResource) ImportState(ctx context.Context, req resource
 		return
 	}
 
-	if domainResponse.Data.State != consts.DomainStateRegistered {
+	if domainResponse.Data.State != consts.DomainStateRegistered && !usingDomainAndRegistrationID {
 		resp.Diagnostics.AddError(
 			fmt.Sprintf("domain %s is not registered", domainName),
 			"domain must be registered before it can be imported",

--- a/internal/framework/resources/registered_domain/import.go
+++ b/internal/framework/resources/registered_domain/import.go
@@ -7,25 +7,30 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/terraform-providers/terraform-provider-dnsimple/internal/framework/common"
 )
 
 func (r *RegisteredDomainResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	parts := strings.Split(req.ID, "_")
-	if len(parts) != 2 {
-		resp.Diagnostics.AddError("resource import invalid ID", fmt.Sprintf("wrong format of import ID (%s), use: '<domain-name>_<domain-registration-id>'", req.ID))
-		return
-	}
 	domainName := parts[0]
-	domainRegistrationID := parts[1]
 
-	domainRegistrationResponse, err := r.config.Client.Registrar.GetDomainRegistration(ctx, r.config.AccountID, domainName, domainRegistrationID)
+	if len(parts) == 2 {
+		domainRegistrationID := parts[1]
 
-	if err != nil {
-		resp.Diagnostics.AddError(
-			fmt.Sprintf("failed to find DNSimple Domain Registration ID: %s", domainRegistrationID),
-			err.Error(),
-		)
-		return
+		domainRegistrationResponse, err := r.config.Client.Registrar.GetDomainRegistration(ctx, r.config.AccountID, domainName, domainRegistrationID)
+
+		if err != nil {
+			resp.Diagnostics.AddError(
+				fmt.Sprintf("failed to find DNSimple Domain Registration ID: %s", domainRegistrationID),
+				err.Error(),
+			)
+			return
+		}
+		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("domain_registration").AtName("id"), domainRegistrationResponse.Data.ID)...)
+	} else {
+		resp.Private.SetKey(ctx, "skip_domain_registration", []byte(`true`))
+		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("domain_registration"), basetypes.NewObjectNull(common.DomainRegistrationAttrType))...)
 	}
 
 	domainResponse, err := r.config.Client.Domains.GetDomain(ctx, r.config.AccountID, domainName)
@@ -40,5 +45,4 @@ func (r *RegisteredDomainResource) ImportState(ctx context.Context, req resource
 
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), domainResponse.Data.ID)...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("name"), domainResponse.Data.Name)...)
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("domain_registration").AtName("id"), domainRegistrationResponse.Data.ID)...)
 }

--- a/internal/framework/resources/registered_domain/modifiers.go
+++ b/internal/framework/resources/registered_domain/modifiers.go
@@ -27,6 +27,15 @@ func (m domainRegistrationState) MarkdownDescription(ctx context.Context) string
 }
 
 func (m domainRegistrationState) PlanModifyObject(ctx context.Context, req planmodifier.ObjectRequest, resp *planmodifier.ObjectResponse) {
+	if value, diags := req.Private.GetKey(ctx, "skip_domain_registration"); diags.HasError() {
+		resp.Diagnostics.Append(diags...)
+	} else {
+		if string(value) == "true" {
+			resp.PlanValue = basetypes.NewObjectNull(common.DomainRegistrationAttrType)
+			return
+		}
+	}
+
 	if !req.ConfigValue.IsNull() || req.PlanValue.IsUnknown() || req.PlanValue.IsNull() {
 		return
 	}

--- a/internal/framework/resources/registered_domain/modifiers_test.go
+++ b/internal/framework/resources/registered_domain/modifiers_test.go
@@ -40,46 +40,66 @@ func TestDomainRegistrationStateModifier(t *testing.T) {
 	ctx := context.Background()
 
 	type testCase struct {
-		plannedValue  types.Object
-		currentValue  types.Object
-		expectedValue types.Object
-		expectError   bool
+		skipDomainRegistration bool
+		plannedValue           types.Object
+		currentValue           types.Object
+		expectedValue          types.Object
+		expectError            bool
 	}
 	tests := map[string]testCase{
+		"imported has no plan and state and is unkown": {
+			skipDomainRegistration: true,
+			plannedValue:           types.ObjectUnknown(common.DomainRegistrationAttrType),
+			currentValue:           types.ObjectNull(common.DomainRegistrationAttrType),
+			expectedValue:          types.ObjectNull(common.DomainRegistrationAttrType),
+		},
+		"imported has no plan and is null": {
+			skipDomainRegistration: true,
+			plannedValue:           types.ObjectNull(common.DomainRegistrationAttrType),
+			currentValue:           types.ObjectNull(common.DomainRegistrationAttrType),
+			expectedValue:          types.ObjectNull(common.DomainRegistrationAttrType),
+		},
 		"not registered has plan and state": {
-			plannedValue:  domainRegistrationToObject(ctx, &common.DomainRegistration{State: types.StringValue(consts.DomainStateNew)}),
-			currentValue:  domainRegistrationToObject(ctx, &common.DomainRegistration{State: types.StringValue(consts.DomainStateNew)}),
-			expectedValue: domainRegistrationToObject(ctx, &common.DomainRegistration{State: types.StringValue(consts.DomainStateRegistered)}),
+			skipDomainRegistration: false,
+			plannedValue:           domainRegistrationToObject(ctx, &common.DomainRegistration{State: types.StringValue(consts.DomainStateNew)}),
+			currentValue:           domainRegistrationToObject(ctx, &common.DomainRegistration{State: types.StringValue(consts.DomainStateNew)}),
+			expectedValue:          domainRegistrationToObject(ctx, &common.DomainRegistration{State: types.StringValue(consts.DomainStateRegistered)}),
 		},
 		"state null but plan is known": {
-			plannedValue:  domainRegistrationToObject(ctx, &common.DomainRegistration{State: types.StringValue(consts.DomainStateNew)}),
-			currentValue:  types.ObjectNull(common.DomainRegistrationAttrType),
-			expectedValue: domainRegistrationToObject(ctx, &common.DomainRegistration{State: types.StringValue(consts.DomainStateRegistered)}),
+			skipDomainRegistration: false,
+			plannedValue:           domainRegistrationToObject(ctx, &common.DomainRegistration{State: types.StringValue(consts.DomainStateNew)}),
+			currentValue:           types.ObjectNull(common.DomainRegistrationAttrType),
+			expectedValue:          domainRegistrationToObject(ctx, &common.DomainRegistration{State: types.StringValue(consts.DomainStateRegistered)}),
 		},
 		"null planned": {
-			plannedValue:  types.ObjectNull(common.DomainRegistrationAttrType),
-			currentValue:  domainRegistrationToObject(ctx, &common.DomainRegistration{State: types.StringValue(consts.DomainStateFailed)}),
-			expectedValue: types.ObjectNull(common.DomainRegistrationAttrType),
+			skipDomainRegistration: false,
+			plannedValue:           types.ObjectNull(common.DomainRegistrationAttrType),
+			currentValue:           domainRegistrationToObject(ctx, &common.DomainRegistration{State: types.StringValue(consts.DomainStateFailed)}),
+			expectedValue:          types.ObjectNull(common.DomainRegistrationAttrType),
 		},
 		"state failing": {
-			plannedValue:  domainRegistrationToObject(ctx, &common.DomainRegistration{State: types.StringValue(consts.DomainStateFailed)}),
-			currentValue:  domainRegistrationToObject(ctx, &common.DomainRegistration{State: types.StringValue(consts.DomainStateFailed)}),
-			expectedValue: domainRegistrationToObject(ctx, &common.DomainRegistration{State: types.StringValue(consts.DomainStateFailed)}),
+			skipDomainRegistration: false,
+			plannedValue:           domainRegistrationToObject(ctx, &common.DomainRegistration{State: types.StringValue(consts.DomainStateFailed)}),
+			currentValue:           domainRegistrationToObject(ctx, &common.DomainRegistration{State: types.StringValue(consts.DomainStateFailed)}),
+			expectedValue:          domainRegistrationToObject(ctx, &common.DomainRegistration{State: types.StringValue(consts.DomainStateFailed)}),
 		},
 		"state cancelling": {
-			plannedValue:  domainRegistrationToObject(ctx, &common.DomainRegistration{State: types.StringValue(consts.DomainStateCancelling)}),
-			currentValue:  domainRegistrationToObject(ctx, &common.DomainRegistration{State: types.StringValue(consts.DomainStateCancelling)}),
-			expectedValue: domainRegistrationToObject(ctx, &common.DomainRegistration{State: types.StringValue(consts.DomainStateCancelling)}),
+			skipDomainRegistration: false,
+			plannedValue:           domainRegistrationToObject(ctx, &common.DomainRegistration{State: types.StringValue(consts.DomainStateCancelling)}),
+			currentValue:           domainRegistrationToObject(ctx, &common.DomainRegistration{State: types.StringValue(consts.DomainStateCancelling)}),
+			expectedValue:          domainRegistrationToObject(ctx, &common.DomainRegistration{State: types.StringValue(consts.DomainStateCancelling)}),
 		},
 		"state cancelled": {
-			plannedValue:  domainRegistrationToObject(ctx, &common.DomainRegistration{State: types.StringValue(consts.DomainStateCancelled)}),
-			currentValue:  domainRegistrationToObject(ctx, &common.DomainRegistration{State: types.StringValue(consts.DomainStateCancelled)}),
-			expectedValue: domainRegistrationToObject(ctx, &common.DomainRegistration{State: types.StringValue(consts.DomainStateCancelled)}),
+			skipDomainRegistration: false,
+			plannedValue:           domainRegistrationToObject(ctx, &common.DomainRegistration{State: types.StringValue(consts.DomainStateCancelled)}),
+			currentValue:           domainRegistrationToObject(ctx, &common.DomainRegistration{State: types.StringValue(consts.DomainStateCancelled)}),
+			expectedValue:          domainRegistrationToObject(ctx, &common.DomainRegistration{State: types.StringValue(consts.DomainStateCancelled)}),
 		},
 		"on create": {
-			plannedValue:  types.ObjectNull(common.DomainRegistrationAttrType),
-			currentValue:  types.ObjectNull(common.DomainRegistrationAttrType),
-			expectedValue: types.ObjectNull(common.DomainRegistrationAttrType),
+			skipDomainRegistration: false,
+			plannedValue:           types.ObjectNull(common.DomainRegistrationAttrType),
+			currentValue:           types.ObjectNull(common.DomainRegistrationAttrType),
+			expectedValue:          types.ObjectNull(common.DomainRegistrationAttrType),
 		},
 	}
 
@@ -94,6 +114,11 @@ func TestDomainRegistrationStateModifier(t *testing.T) {
 				PlanValue:  test.plannedValue,
 				StateValue: test.currentValue,
 			}
+
+			if test.skipDomainRegistration {
+				request.Private.SetKey(ctx, "skipDomainRegistration", []byte("true"))
+			}
+
 			response := planmodifier.ObjectResponse{
 				PlanValue: request.PlanValue,
 			}

--- a/internal/framework/resources/registered_domain/resource_test.go
+++ b/internal/framework/resources/registered_domain/resource_test.go
@@ -155,6 +155,30 @@ func TestAccRegisteredDomainResource_WithOptions(t *testing.T) {
 	})
 }
 
+func TestAccRegisteredDomainResource_ImportedWithDomainOnly(t *testing.T) {
+	domainName := os.Getenv("DNSIMPLE_DOMAIN")
+	resourceName := "dnsimple_registered_domain.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckRegisteredDomain(t) },
+		ProtoV6ProviderFactories: test_utils.TestAccProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				ResourceName:      resourceName,
+				Config:            testAccRegisteredDomainResourceConfig(domainName, 1234),
+				ImportStateId:     domainName,
+				ImportState:       true,
+				ImportStateVerify: false,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", domainName),
+					resource.TestCheckResourceAttr(resourceName, "state", "registered"),
+					resource.TestCheckNoResourceAttr(resourceName, "domain_registration"),
+				),
+			},
+		},
+	})
+}
+
 func testAccPreCheckRegisteredDomain(t *testing.T) {
 	test_utils.TestAccPreCheck(t)
 	if os.Getenv("DNSIMPLE_CONTACT_ID") == "" {


### PR DESCRIPTION
This PR adds support for importing registered domains into a `dnsimple_registered_domain` resource.

Also took the opportunity to update documentation across resources and push a fix for a bug I came across in the ds record.