### PR TITLE
Fix error when no alternate names are provided for the Let's Encrypt certificate resource

### DIFF
--- a/internal/framework/resources/lets_encrypt_certificate_resource.go
+++ b/internal/framework/resources/lets_encrypt_certificate_resource.go
@@ -143,9 +143,7 @@ func (r *LetsEncryptCertificateResource) Create(ctx context.Context, req resourc
 	// Read Terraform plan data into the model
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
 	alternateNames := make([]string, len(data.AlternateNames.Elements()))
-	if !data.AlternateNames.IsNull() {
-		resp.Diagnostics.Append(data.AlternateNames.ElementsAs(ctx, alternateNames, false)...)
-	}
+	resp.Diagnostics.Append(data.AlternateNames.ElementsAs(ctx, &alternateNames, false)...)
 
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/framework/resources/lets_encrypt_certificate_resource.go
+++ b/internal/framework/resources/lets_encrypt_certificate_resource.go
@@ -143,7 +143,9 @@ func (r *LetsEncryptCertificateResource) Create(ctx context.Context, req resourc
 	// Read Terraform plan data into the model
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
 	alternateNames := make([]string, len(data.AlternateNames.Elements()))
-	resp.Diagnostics.Append(data.AlternateNames.ElementsAs(ctx, alternateNames, false)...)
+	if !data.AlternateNames.IsNull() {
+		resp.Diagnostics.Append(data.AlternateNames.ElementsAs(ctx, alternateNames, false)...)
+	}
 
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/framework/resources/lets_encrypt_certificate_resource_test.go
+++ b/internal/framework/resources/lets_encrypt_certificate_resource_test.go
@@ -57,6 +57,46 @@ func TestAccLetsEncryptCertificateResource(t *testing.T) {
 	})
 }
 
+func TestAccLetsEncryptCertificateResource_NoAlternateNames(t *testing.T) {
+	if os.Getenv("DNSIMPLE_SANDBOX") != "false" {
+		t.Skip("DNSIMPLE_SANDBOX is not set to `false` (read in CONTRIBUTING.md how to run this test)")
+		return
+	}
+	resourceName := "dnsimple_lets_encrypt_certificate.test"
+
+	domainId := os.Getenv("DNSIMPLE_DOMAIN")
+	certName := os.Getenv("DNSIMPLE_CERTIFICATE_NAME")
+	certAutoRenew := os.Getenv("DNSIMPLE_CERTIFICATE_AUTO_RENEW") == "1"
+	certSigAlg := os.Getenv("DNSIMPLE_CERTIFICATE_SIGNATURE_ALGORITHM")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { test_utils.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckLetsEncryptCertificateResourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLetsEncryptCertificateResourceConfig_NoAlternateNames(domainId, certAutoRenew, certName, certSigAlg),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "domain_id", domainId),
+					resource.TestCheckResourceAttr(resourceName, "name", certName),
+					resource.TestCheckResourceAttr(resourceName, "alternate_names.#", "0"),
+					resource.TestCheckResourceAttrSet(resourceName, "years"),
+					resource.TestCheckResourceAttrSet(resourceName, "state"),
+					resource.TestCheckResourceAttrSet(resourceName, "authority_identifier"),
+					resource.TestCheckResourceAttr(resourceName, "auto_renew", strconv.FormatBool(certAutoRenew)),
+					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
+					resource.TestCheckResourceAttrSet(resourceName, "updated_at"),
+					resource.TestCheckResourceAttrSet(resourceName, "csr"),
+					resource.TestCheckResourceAttr(resourceName, "signature_algorithm", certSigAlg),
+				),
+			},
+			// Update is a no-op
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+
 // We cannot delete certificates from the server.
 func testAccCheckLetsEncryptCertificateResourceDestroy(state *terraform.State) error {
 	return nil
@@ -75,4 +115,14 @@ resource "dnsimple_lets_encrypt_certificate" "test" {
 	alternate_names = %[4]s
 	signature_algorithm = %[5]q
 }`, domainId, autoRenew, name, string(alternateNamesRaw), signatureAlgorithm)
+}
+
+func testAccLetsEncryptCertificateResourceConfig_NoAlternateNames(domainId string, autoRenew bool, name string, signatureAlgorithm string) string {
+	return fmt.Sprintf(`
+resource "dnsimple_lets_encrypt_certificate" "test" {
+	domain_id = %[1]q
+	auto_renew = %[2]t
+	name = %[3]q
+	signature_algorithm = %[4]q
+}`, domainId, autoRenew, name, signatureAlgorithm)
 }


### PR DESCRIPTION
When the `alternate_names` attribute is omitted in a `dnsimple_lets_encrypt_certificate` resource, an error occurs like "target must be a pointer, got []string, which is a slice". Fixes #109.