### PR TITLE
Add transfer lock management to registered domain resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,18 +2,13 @@
 
 ## main
 
-## 1.3.0 (Unreleased)
-
-FEATURES:
-
-- **Updated Resource:** `dnsimple_registered_domain` (dnsimple/terraform-provider-dnsimple#143)
-
 ## 1.2.0 (Unreleased)
 
 FEATURES:
 
 - **New Resource:** `dnsimple_registered_domain_contact` (dnsimple/terraform-provider-dnsimple#142)
 - **New Data Source:** `dnsimple_registrant_change_check` (dnsimple/terraform-provider-dnsimple#142)
+- **Updated Resource:** `dnsimple_registered_domain` now supports `transfer_lock_enabled` argument which you can use to manage the domain transfer lock state of your registered domains (dnsimple/terraform-provider-dnsimple#143)
 
 ## 1.1.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## main
 
+## 1.3.0 (Unreleased)
+
+FEATURES:
+
+- **Updated Resource:** `dnsimple_registered_domain` (dnsimple/terraform-provider-dnsimple#143)
+
 ## 1.2.0 (Unreleased)
 
 FEATURES:

--- a/docs/resources/registered_domain.md
+++ b/docs/resources/registered_domain.md
@@ -31,6 +31,7 @@ resource "dnsimple_registered_domain" "appleseed_bio" {
 
   contact_id            = dnsimple_contact.alice_main.id
   auto_renew_enabled    = true
+  transfer_lock_enabled = true
   whois_privacy_enabled = true
   dnssec_enabled        = false
 
@@ -49,6 +50,7 @@ The following argument(s) are supported:
 * `auto_renew_enabled` - (Optional) Whether the domain should be set to auto-renew (default: `false`)
 * `whois_privacy_enabled` - (Optional) Whether the domain should have WhoIs privacy enabled (default: `false`)
 * `dnssec_enabled` - (Optional) Whether the domain should have DNSSEC enabled (default: `false`)
+* `transfer_lock_enabled` - (Optional) Whether the domain transfer lock protection is enabled (default: `true`)
 * `premium_price` - (Optional) The premium price for the domain registration. This is only required if the domain is a premium domain. You can use our [Check domain API](https://developer.dnsimple.com/v2/registrar/#checkDomain) to check if a domain is premium. And [Retrieve domain prices API](https://developer.dnsimple.com/v2/registrar/#getDomainPrices) to retrieve the premium price for a domain.
 * `extended_attributes` - (Optional) A map of extended attributes to be set for the domain registration. To see if there are any required extended attributes for any TLD use our [Lists the TLD Extended Attributes API](https://developer.dnsimple.com/v2/tlds/#getTldExtendedAttributes).
 * `timeouts` - (Optional) (see [below for nested schema](#nestedblock--timeouts))

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/terraform-providers/terraform-provider-dnsimple
 
 require (
-	github.com/dnsimple/dnsimple-go v1.3.1-0.20230829135611-32f5abe89db0
+	github.com/dnsimple/dnsimple-go v1.4.0
 	github.com/hashicorp/terraform-plugin-docs v0.14.1
 	github.com/hashicorp/terraform-plugin-framework v1.2.0
 	github.com/hashicorp/terraform-plugin-go v0.15.0

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/terraform-providers/terraform-provider-dnsimple
 
 require (
-	github.com/dnsimple/dnsimple-go v1.3.0
+	github.com/dnsimple/dnsimple-go v1.3.1-0.20230829135611-32f5abe89db0
 	github.com/hashicorp/terraform-plugin-docs v0.14.1
 	github.com/hashicorp/terraform-plugin-framework v1.2.0
 	github.com/hashicorp/terraform-plugin-go v0.15.0

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dnsimple/dnsimple-go v1.3.0 h1:8hv9JZdfMLGUp5QIX1VndDWsMd3kY/9H3TRA7Zyyo/E=
 github.com/dnsimple/dnsimple-go v1.3.0/go.mod h1:G7a16dj2TULTldjxg1EAcSxonEqx0gkTOP8PESBai+4=
+github.com/dnsimple/dnsimple-go v1.3.1-0.20230829135611-32f5abe89db0 h1:TbxJZmxAU1Tu9hCV8R7BJHxbVufPTteCXjdfYIUKH2E=
+github.com/dnsimple/dnsimple-go v1.3.1-0.20230829135611-32f5abe89db0/go.mod h1:G7a16dj2TULTldjxg1EAcSxonEqx0gkTOP8PESBai+4=
 github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
@@ -178,6 +180,7 @@ github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSg
 github.com/rogpeppe/go-internal v1.6.1 h1:/FiVV8dS/e+YqF2JvO3yXRFbBLTIuSDkuC7aBOAvL+k=
 github.com/russross/blackfriday v1.6.0 h1:KqfZb0pUVN2lYqZUYRddxF4OR8ZMURnJIG5Y3VRLtww=
 github.com/russross/blackfriday v1.6.0/go.mod h1:ti0ldHuxg49ri4ksnFxlkCfN+hvslNlmVHqNRXXJNAY=
+github.com/sebdah/goldie v1.0.0/go.mod h1:jXP4hmWywNEwZzhMuv2ccnqTSFpuq8iyQhtQdkkZBH4=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=
 github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
@@ -200,8 +203,10 @@ github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXl
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
+github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/msgpack/v5 v5.3.5 h1:5gO0H1iULLWGhs2H5tbAHIZTV8/cYafcFOr9znI5mJU=
 github.com/vmihailenco/msgpack/v5 v5.3.5/go.mod h1:7xyJ9e+0+9SaZT0Wt1RGleJXzli6Q/V5KbhBonMG9jc=
+github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
 github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
 github.com/xanzy/ssh-agent v0.3.0 h1:wUMzuKtKilRgBAD1sUb8gOwwRr2FGoBVumcjoOACClI=
@@ -209,6 +214,7 @@ github.com/xanzy/ssh-agent v0.3.0/go.mod h1:3s9xbODqPuuhK9JV1R321M/FlMZSBvE5aY6e
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/zclconf/go-cty v1.13.1 h1:0a6bRwuiSHtAmqCqNOE+c2oHgepv0ctoxU4FUe43kwc=
 github.com/zclconf/go-cty v1.13.1/go.mod h1:YKQzy/7pZ7iq2jNFzy5go57xdxdWoLLpaEp4u238AE0=
+github.com/zclconf/go-cty-debug v0.0.0-20191215020915-b22d67c1ba0b/go.mod h1:ZRKQfBXbGkpdV6QMzT3rU1kSTAnfu1dO8dPKjYprgj8=
 golang.org/x/crypto v0.0.0-20190219172222-a4c6cb3142f2/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20200414173820-0848c9571904/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=

--- a/go.sum
+++ b/go.sum
@@ -28,10 +28,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dnsimple/dnsimple-go v1.3.0 h1:8hv9JZdfMLGUp5QIX1VndDWsMd3kY/9H3TRA7Zyyo/E=
-github.com/dnsimple/dnsimple-go v1.3.0/go.mod h1:G7a16dj2TULTldjxg1EAcSxonEqx0gkTOP8PESBai+4=
-github.com/dnsimple/dnsimple-go v1.3.1-0.20230829135611-32f5abe89db0 h1:TbxJZmxAU1Tu9hCV8R7BJHxbVufPTteCXjdfYIUKH2E=
-github.com/dnsimple/dnsimple-go v1.3.1-0.20230829135611-32f5abe89db0/go.mod h1:G7a16dj2TULTldjxg1EAcSxonEqx0gkTOP8PESBai+4=
+github.com/dnsimple/dnsimple-go v1.4.0 h1:nBqtRXI9dYx6k6YJDlPZ1x/JuTP86KMtgbsBj6/6sMA=
+github.com/dnsimple/dnsimple-go v1.4.0/go.mod h1:G7a16dj2TULTldjxg1EAcSxonEqx0gkTOP8PESBai+4=
 github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
@@ -180,7 +178,6 @@ github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSg
 github.com/rogpeppe/go-internal v1.6.1 h1:/FiVV8dS/e+YqF2JvO3yXRFbBLTIuSDkuC7aBOAvL+k=
 github.com/russross/blackfriday v1.6.0 h1:KqfZb0pUVN2lYqZUYRddxF4OR8ZMURnJIG5Y3VRLtww=
 github.com/russross/blackfriday v1.6.0/go.mod h1:ti0ldHuxg49ri4ksnFxlkCfN+hvslNlmVHqNRXXJNAY=
-github.com/sebdah/goldie v1.0.0/go.mod h1:jXP4hmWywNEwZzhMuv2ccnqTSFpuq8iyQhtQdkkZBH4=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=
 github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
@@ -203,10 +200,8 @@ github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXl
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
-github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/msgpack/v5 v5.3.5 h1:5gO0H1iULLWGhs2H5tbAHIZTV8/cYafcFOr9znI5mJU=
 github.com/vmihailenco/msgpack/v5 v5.3.5/go.mod h1:7xyJ9e+0+9SaZT0Wt1RGleJXzli6Q/V5KbhBonMG9jc=
-github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
 github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
 github.com/xanzy/ssh-agent v0.3.0 h1:wUMzuKtKilRgBAD1sUb8gOwwRr2FGoBVumcjoOACClI=
@@ -214,7 +209,6 @@ github.com/xanzy/ssh-agent v0.3.0/go.mod h1:3s9xbODqPuuhK9JV1R321M/FlMZSBvE5aY6e
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/zclconf/go-cty v1.13.1 h1:0a6bRwuiSHtAmqCqNOE+c2oHgepv0ctoxU4FUe43kwc=
 github.com/zclconf/go-cty v1.13.1/go.mod h1:YKQzy/7pZ7iq2jNFzy5go57xdxdWoLLpaEp4u238AE0=
-github.com/zclconf/go-cty-debug v0.0.0-20191215020915-b22d67c1ba0b/go.mod h1:ZRKQfBXbGkpdV6QMzT3rU1kSTAnfu1dO8dPKjYprgj8=
 golang.org/x/crypto v0.0.0-20190219172222-a4c6cb3142f2/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20200414173820-0848c9571904/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=

--- a/internal/framework/resources/registered_domain/read.go
+++ b/internal/framework/resources/registered_domain/read.go
@@ -60,10 +60,20 @@ func (r *RegisteredDomainResource) Read(ctx context.Context, req resource.ReadRe
 		return
 	}
 
+	transferLockResponse, err := r.config.Client.Registrar.GetDomainTransferLock(ctx, r.config.AccountID, data.Name.ValueString())
+
+	if err != nil {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("failed to read DNSimple Domain transfer lock status: %s", data.Name.ValueString()),
+			err.Error(),
+		)
+		return
+	}
+
 	if domainRegistrationResponse == nil {
-		diags = r.updateModelFromAPIResponse(ctx, data, nil, domainResponse.Data, dnssecResponse.Data)
+		diags = r.updateModelFromAPIResponse(ctx, data, nil, domainResponse.Data, dnssecResponse.Data, transferLockResponse.Data)
 	} else {
-		diags = r.updateModelFromAPIResponse(ctx, data, domainRegistrationResponse.Data, domainResponse.Data, dnssecResponse.Data)
+		diags = r.updateModelFromAPIResponse(ctx, data, domainRegistrationResponse.Data, domainResponse.Data, dnssecResponse.Data, transferLockResponse.Data)
 	}
 
 	if diags != nil && diags.HasError() {

--- a/internal/framework/resources/registered_domain/resource_test.go
+++ b/internal/framework/resources/registered_domain/resource_test.go
@@ -121,7 +121,7 @@ func TestAccRegisteredDomainResource_WithOptions(t *testing.T) {
 		CheckDestroy:             testAccCheckRegisteredDomainResourceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRegisteredDomainResourceConfig_WithOptions(domainName, contactID, false, true, true),
+				Config: testAccRegisteredDomainResourceConfig_WithOptions(domainName, contactID, false, true, true, true),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", domainName),
 					resource.TestCheckResourceAttr(resourceName, "state", "registered"),
@@ -129,11 +129,12 @@ func TestAccRegisteredDomainResource_WithOptions(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "auto_renew_enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "whois_privacy_enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "dnssec_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "transfer_lock_enabled", "true"),
 					resource.TestCheckResourceAttrSet(resourceName, "expires_at"),
 				),
 			},
 			{
-				Config: testAccRegisteredDomainResourceConfig_WithOptions(domainName, contactID, true, false, false),
+				Config: testAccRegisteredDomainResourceConfig_WithOptions(domainName, contactID, true, false, false, false),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", domainName),
 					resource.TestCheckResourceAttr(resourceName, "state", "registered"),
@@ -141,6 +142,7 @@ func TestAccRegisteredDomainResource_WithOptions(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "auto_renew_enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "whois_privacy_enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "dnssec_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "transfer_lock_enabled", "false"),
 					resource.TestCheckResourceAttrSet(resourceName, "expires_at"),
 				),
 			},
@@ -274,7 +276,7 @@ resource "dnsimple_registered_domain" "test" {
 }`, domainName, contactId)
 }
 
-func testAccRegisteredDomainResourceConfig_WithOptions(domainName string, contactId int, withAutoRenew, withWhoisPrivacy, withDNSSEC bool) string {
+func testAccRegisteredDomainResourceConfig_WithOptions(domainName string, contactId int, withAutoRenew, withWhoisPrivacy, withDNSSEC bool, withTransferLock bool) string {
 	return fmt.Sprintf(`
 resource "dnsimple_registered_domain" "test" {
 	name = %[1]q
@@ -283,5 +285,6 @@ resource "dnsimple_registered_domain" "test" {
 	auto_renew_enabled = %[3]t
 	whois_privacy_enabled = %[4]t
 	dnssec_enabled = %[5]t
-}`, domainName, contactId, withAutoRenew, withWhoisPrivacy, withDNSSEC)
+	transfer_lock_enabled = %[6]t
+}`, domainName, contactId, withAutoRenew, withWhoisPrivacy, withDNSSEC, withTransferLock)
 }

--- a/internal/framework/resources/registered_domain/schema.go
+++ b/internal/framework/resources/registered_domain/schema.go
@@ -40,6 +40,7 @@ type RegisteredDomainResourceModel struct {
 	AutoRenewEnabled    types.Bool   `tfsdk:"auto_renew_enabled"`
 	WhoisPrivacyEnabled types.Bool   `tfsdk:"whois_privacy_enabled"`
 	DNSSECEnabled       types.Bool   `tfsdk:"dnssec_enabled"`
+	TransferLockEnabled types.Bool   `tfsdk:"transfer_lock_enabled"`
 	ContactId           types.Int64  `tfsdk:"contact_id"`
 	ExpiresAt           types.String `tfsdk:"expires_at"`
 	ExtendedAttributes  types.Map    `tfsdk:"extended_attributes"`
@@ -85,6 +86,10 @@ func (r *RegisteredDomainResource) Schema(_ context.Context, _ resource.SchemaRe
 				Computed: true,
 			},
 			"dnssec_enabled": schema.BoolAttribute{
+				Optional: true,
+				Computed: true,
+			},
+			"transfer_lock_enabled": schema.BoolAttribute{
 				Optional: true,
 				Computed: true,
 			},


### PR DESCRIPTION
Adds the ability to manage the registrar service domain transfer lock as part of the `registered_domain` resource

Belongs to https://github.com/dnsimple/dnsimple-business/issues/1728

Depends on https://github.com/dnsimple/dnsimple-go/pull/147

### Pre-Release Tasks

- [x] Update dnsimple-go version
