### PR TITLE
Support regional records

### DIFF
--- a/docs/resources/zone_record.md
+++ b/docs/resources/zone_record.md
@@ -40,6 +40,7 @@ The following arguments are supported:
 * `type` - (Required) The type of the record
 * `ttl` - (Optional) The TTL of the record - defaults to 3600
 * `priority` - (Optional) The priority of the record - only useful for some record types
+* `regions` - (Optional) A list of regions to serve the record from.
 
 
 ## Attributes Reference

--- a/docs/resources/zone_record.md
+++ b/docs/resources/zone_record.md
@@ -40,7 +40,7 @@ The following arguments are supported:
 * `type` - (Required) The type of the record
 * `ttl` - (Optional) The TTL of the record - defaults to 3600
 * `priority` - (Optional) The priority of the record - only useful for some record types
-* `regions` - (Optional) A list of regions to serve the record from.
+* `regions` - (Optional) A list of regions to serve the record from. You can find a list of supported values in our [developer documentation](https://developer.dnsimple.com/v2/zones/records/).
 
 
 ## Attributes Reference

--- a/internal/framework/resources/zone_record_resource.go
+++ b/internal/framework/resources/zone_record_resource.go
@@ -44,6 +44,7 @@ type ZoneRecordResourceModel struct {
 	Name          types.String `tfsdk:"name"`
 	QualifiedName types.String `tfsdk:"qualified_name"`
 	Type          types.String `tfsdk:"type"`
+	Regions       types.List   `tfsdk:"regions"`
 	Value         types.String `tfsdk:"value"`
 	TTL           types.Int64  `tfsdk:"ttl"`
 	Priority      types.Int64  `tfsdk:"priority"`
@@ -80,6 +81,10 @@ func (r *ZoneRecordResource) Schema(_ context.Context, _ resource.SchemaRequest,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
+			},
+			"regions": schema.ListAttribute{
+				Optional:    true,
+				ElementType: types.StringType,
 			},
 			"value": schema.StringAttribute{
 				Required: true,
@@ -125,6 +130,8 @@ func (r *ZoneRecordResource) Create(ctx context.Context, req resource.CreateRequ
 
 	// Read Terraform plan data into the model
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	regions := make([]string, len(data.Regions.Elements()))
+	resp.Diagnostics.Append(data.Regions.ElementsAs(ctx, &regions, false)...)
 
 	if resp.Diagnostics.HasError() {
 		return
@@ -134,6 +141,7 @@ func (r *ZoneRecordResource) Create(ctx context.Context, req resource.CreateRequ
 		Name:    dnsimple.String(data.Name.ValueString()),
 		Type:    data.Type.ValueString(),
 		Content: data.Value.ValueString(),
+		Regions: regions,
 		TTL:     int(data.TTL.ValueInt64()),
 	}
 
@@ -248,6 +256,8 @@ func (r *ZoneRecordResource) Update(ctx context.Context, req resource.UpdateRequ
 
 	// Read Terraform plan data into the model
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	regions := make([]string, len(data.Regions.Elements()))
+	resp.Diagnostics.Append(data.Regions.ElementsAs(ctx, &regions, false)...)
 
 	if resp.Diagnostics.HasError() {
 		return
@@ -257,6 +267,7 @@ func (r *ZoneRecordResource) Update(ctx context.Context, req resource.UpdateRequ
 		Name:    dnsimple.String(data.Name.ValueString()),
 		Type:    data.Type.ValueString(),
 		Content: data.Value.ValueString(),
+		Regions: regions,
 		TTL:     int(data.TTL.ValueInt64()),
 	}
 

--- a/internal/framework/resources/zone_record_resource_test.go
+++ b/internal/framework/resources/zone_record_resource_test.go
@@ -34,6 +34,18 @@ func TestAccZoneRecordResource(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccZoneRecordResourceStandardWithRegionsConfig(domainName, []string{"IAD", "SYD"}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "zone_name", domainName),
+					resource.TestCheckResourceAttr(resourceName, "qualified_name", "terraform."+domainName),
+					resource.TestCheckResourceAttr(resourceName, "ttl", "2800"),
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "#regions", "2"),
+					resource.TestCheckResourceAttr(resourceName, "regions.0", "IAD"),
+					resource.TestCheckResourceAttr(resourceName, "regions.1", "SYD"),
+				),
+			},
+			{
 				Config: testAccZoneRecordResourceStandardWithDefaultsConfig(domainName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "zone_name", domainName),
@@ -247,8 +259,20 @@ resource "dnsimple_zone_record" "test" {
 	value = "192.168.0.10"
 	type = "A"
 	ttl = 2800
-	regions = ["IAD", "SYD"]
 }`, domainName)
+}
+
+func testAccZoneRecordResourceStandardWithRegionsConfig(domainName string, regions []string) string {
+	return fmt.Sprintf(`
+resource "dnsimple_zone_record" "test" {
+	zone_name = %[1]q
+
+	name = "terraform"
+	value = "192.168.0.10"
+	type = "A"
+	ttl = 2800
+	regions = %[2]q
+}`, domainName, regions)
 }
 
 func testAccZoneRecordResourceStandardWithDefaultsConfig(domainName string) string {

--- a/internal/framework/resources/zone_record_resource_test.go
+++ b/internal/framework/resources/zone_record_resource_test.go
@@ -2,6 +2,7 @@ package resources_test
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -263,6 +264,10 @@ resource "dnsimple_zone_record" "test" {
 }
 
 func testAccZoneRecordResourceStandardWithRegionsConfig(domainName string, regions []string) string {
+	regionsRaw, err := json.Marshal(regions)
+	if err != nil {
+		panic(err)
+	}
 	return fmt.Sprintf(`
 resource "dnsimple_zone_record" "test" {
 	zone_name = %[1]q
@@ -271,8 +276,8 @@ resource "dnsimple_zone_record" "test" {
 	value = "192.168.0.10"
 	type = "A"
 	ttl = 2800
-	regions = %[2]q
-}`, domainName, regions)
+	regions = %[2]s
+}`, domainName, regionsRaw)
 }
 
 func testAccZoneRecordResourceStandardWithDefaultsConfig(domainName string) string {

--- a/internal/framework/resources/zone_record_resource_test.go
+++ b/internal/framework/resources/zone_record_resource_test.go
@@ -31,6 +31,7 @@ func TestAccZoneRecordResource(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "zone_name", domainName),
 					resource.TestCheckResourceAttr(resourceName, "qualified_name", "terraform."+domainName),
 					resource.TestCheckResourceAttr(resourceName, "ttl", "2800"),
+					resource.TestCheckResourceAttr(resourceName, "value", "192.168.0.10"),
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
 				),
 			},
@@ -39,7 +40,8 @@ func TestAccZoneRecordResource(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "zone_name", domainName),
 					resource.TestCheckResourceAttr(resourceName, "qualified_name", "terraform."+domainName),
-					resource.TestCheckResourceAttr(resourceName, "ttl", "2800"),
+					resource.TestCheckResourceAttr(resourceName, "ttl", "4000"),
+					resource.TestCheckResourceAttr(resourceName, "value", "192.168.0.11"),
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
 					resource.TestCheckResourceAttr(resourceName, "#regions", "2"),
 					resource.TestCheckResourceAttr(resourceName, "regions.0", "IAD"),
@@ -273,9 +275,9 @@ resource "dnsimple_zone_record" "test" {
 	zone_name = %[1]q
 
 	name = "terraform"
-	value = "192.168.0.10"
+	value = "192.168.0.11"
 	type = "A"
-	ttl = 2800
+	ttl = 4000
 	regions = %[2]s
 }`, domainName, regionsRaw)
 }

--- a/internal/framework/resources/zone_record_resource_test.go
+++ b/internal/framework/resources/zone_record_resource_test.go
@@ -247,6 +247,7 @@ resource "dnsimple_zone_record" "test" {
 	value = "192.168.0.10"
 	type = "A"
 	ttl = 2800
+	regions = ["IAD", "SYD"]
 }`, domainName)
 }
 


### PR DESCRIPTION
This adds the `regions` list attribute to the `zone_record` resource.