### PR TITLE
Handle normalized record content value

### DIFF
--- a/docs/resources/zone_record.md
+++ b/docs/resources/zone_record.md
@@ -48,6 +48,7 @@ The following arguments are supported:
 * `id` - The record ID
 * `zone_id` - The zone ID of the record
 * `qualified_name` - The FQDN of the record
+* `value_normalized` - The normalized value of the record
 
 ## Import
 

--- a/internal/framework/resources/zone_record_resource_test.go
+++ b/internal/framework/resources/zone_record_resource_test.go
@@ -93,6 +93,54 @@ func TestAccZoneRecordResourceWithPriority(t *testing.T) {
 	})
 }
 
+func TestAccZoneRecordResourceWithTXT(t *testing.T) {
+	domainName := os.Getenv("DNSIMPLE_DOMAIN")
+	resourceName := "dnsimple_zone_record.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { test_utils.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckZoneRecordResourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccZoneRecordResourceTXTConfig(domainName, "test value for TXT record"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "zone_name", domainName),
+					resource.TestCheckResourceAttr(resourceName, "qualified_name", "terraform."+domainName),
+					resource.TestCheckResourceAttr(resourceName, "value", "test value for TXT record"),
+					resource.TestCheckResourceAttr(resourceName, "ttl", "3600"),
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+				),
+			},
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+
+func TestAccZoneRecordResourceWithNormalizedTXT(t *testing.T) {
+	domainName := os.Getenv("DNSIMPLE_DOMAIN")
+	resourceName := "dnsimple_zone_record.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { test_utils.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckZoneRecordResourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccZoneRecordResourceTXTConfig(domainName, "\"test value for TXT record\""),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "zone_name", domainName),
+					resource.TestCheckResourceAttr(resourceName, "qualified_name", "terraform."+domainName),
+					resource.TestCheckResourceAttr(resourceName, "value", "\"test value for TXT record\""),
+					resource.TestCheckResourceAttr(resourceName, "ttl", "3600"),
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+				),
+			},
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+
 func TestAccZoneRecordResourceWithPrefetch(t *testing.T) {
 	domainName := os.Getenv("DNSIMPLE_DOMAIN")
 	resourceName := "dnsimple_zone_record.test"
@@ -239,6 +287,17 @@ func testAccCheckZoneRecordExists(n string, record *dnsimple.ZoneRecord) resourc
 
 		return nil
 	}
+}
+
+func testAccZoneRecordResourceTXTConfig(domainName string, value string) string {
+	return fmt.Sprintf(`
+resource "dnsimple_zone_record" "test" {
+	zone_name = %[1]q
+
+	name = "terraform"
+	value = %[2]q
+	type = "TXT"
+}`, domainName, value)
 }
 
 func testAccZoneRecordResourcePriorityConfig(domainName string) string {


### PR DESCRIPTION
As part of increasing our RFC compliance for TXT records we may normalize user-provided content and as a result unless the user provides a normalized version of the record value we will incorrectly write the normalized value to the state resulting in mismatch between the configuration and the written state.

Fixes https://github.com/dnsimple/terraform-provider-dnsimple/issues/165