### PR TITLE
Update domain delegation name servers to a set

### DIFF
--- a/internal/framework/resources/domain_delegation_resource.go
+++ b/internal/framework/resources/domain_delegation_resource.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -39,7 +38,7 @@ type DomainDelegationResource struct {
 type DomainDelegationResourceModel struct {
 	Id          types.String `tfsdk:"id"`
 	Domain      types.String `tfsdk:"domain"`
-	NameServers types.List   `tfsdk:"name_servers"`
+	NameServers types.Set    `tfsdk:"name_servers"`
 }
 
 func (r *DomainDelegationResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -58,12 +57,9 @@ func (r *DomainDelegationResource) Schema(_ context.Context, _ resource.SchemaRe
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
-			"name_servers": schema.ListAttribute{
+			"name_servers": schema.SetAttribute{
 				Required:    true,
 				ElementType: types.StringType,
-				PlanModifiers: []planmodifier.List{
-					listplanmodifier.RequiresReplace(),
-				},
 			},
 		},
 	}
@@ -190,7 +186,7 @@ func (r *DomainDelegationResource) ImportState(ctx context.Context, req resource
 }
 
 func (r *DomainDelegationResource) updateModelFromAPIResponse(ctx context.Context, delegation *dnsimple.Delegation, data *DomainDelegationResourceModel) diag.Diagnostics {
-	nameServers, diag := types.ListValueFrom(ctx, types.StringType, delegation)
+	nameServers, diag := types.SetValueFrom(ctx, types.StringType, delegation)
 	data.NameServers = nameServers
 	return diag
 }

--- a/internal/framework/resources/domain_delegation_resource_test.go
+++ b/internal/framework/resources/domain_delegation_resource_test.go
@@ -32,6 +32,18 @@ func TestAccDomainDelegationResource(t *testing.T) {
 				),
 			},
 			{
+				Config:             testAccDomainDelegationResourceConfigReversed(domainId),
+				ExpectNonEmptyPlan: false,
+				PlanOnly:           true,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "domain", domainId),
+					resource.TestCheckResourceAttr(resourceName, "name_servers.#", "2"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "name_servers.*", "ns-998.awsdns-60.net"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "name_servers.*", "ns-1556.awsdns-02.co.uk"),
+				),
+			},
+			{
 				ResourceName:      resourceName,
 				ImportStateIdFunc: testAccDomainDelegationImportStateIDFunc(resourceName),
 				ImportState:       true,
@@ -67,5 +79,13 @@ func testAccDomainDelegationResourceConfig(domainId string) string {
 resource "dnsimple_domain_delegation" "test" {
 	domain = %[1]q
 	name_servers = ["ns-998.awsdns-60.net", "ns-1556.awsdns-02.co.uk"]
+}`, domainId)
+}
+
+func testAccDomainDelegationResourceConfigReversed(domainId string) string {
+	return fmt.Sprintf(`
+resource "dnsimple_domain_delegation" "test" {
+	domain = %[1]q
+	name_servers = ["ns-1556.awsdns-02.co.uk", "ns-998.awsdns-60.net"]
 }`, domainId)
 }

--- a/internal/framework/resources/domain_delegation_resource_test.go
+++ b/internal/framework/resources/domain_delegation_resource_test.go
@@ -27,8 +27,8 @@ func TestAccDomainDelegationResource(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
 					resource.TestCheckResourceAttr(resourceName, "domain", domainId),
 					resource.TestCheckResourceAttr(resourceName, "name_servers.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "name_servers.0", "ns-998.awsdns-60.net"),
-					resource.TestCheckResourceAttr(resourceName, "name_servers.1", "ns-1556.awsdns-02.co.uk"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "name_servers.*", "ns-998.awsdns-60.net"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "name_servers.*", "ns-1556.awsdns-02.co.uk"),
 				),
 			},
 			{


### PR DESCRIPTION
Updates the domain delegation resource name servers attribute to a set.

This should prevent order errors and fix https://github.com/dnsimple/terraform-provider-dnsimple/issues/159