### PR TITLE
Stable certificate data source ID

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,23 +60,23 @@ jobs:
       matrix:
         terraform:
           - '1.3.*'
-          - '1.5.*'
           - '1.6.*'
           - '1.7.*'
+          - '1.8.*'
         include:
           - terraform: '1.3.*'
             domain: 'dnsimple-1-0-terraform.bio'
             registrant_contact_id: 10854
             registrant_change_domain: 'peoa1hvrl5s7q7os1bqadhd29uar81nnc4m0oyaloxex9kapsn20u6nr8z6l5h.eu'
-          - terraform: '1.5.*'
+          - terraform: '1.6.*'
             domain: 'dnsimple-1-1-terraform.bio'
             registrant_contact_id: 10169
             registrant_change_domain: '9qy9lpesl2f2o5ya45zyujrggori1mh8sl6k2oz37usv48lhn3ziistg3u5kgv.eu'
-          - terraform: '1.6.*'
+          - terraform: '1.7.*'
             domain: 'dnsimple-1-2-terraform.bio'
             registrant_contact_id: 10854
             registrant_change_domain: 'lqyivkga231hkiqihu0k7bjic2ixd01xs5vex8rmn2iaw0l7gxvhcbicigpfm3.eu'
-          - terraform: '1.7.*'
+          - terraform: '1.8.*'
             domain: 'dnsimple-1-4-terraform.bio'
             registrant_contact_id: 10169
             registrant_change_domain: 'z0u2w48bo5fzgdsh1g7zjpflbpt0tiyl6tmc75ltzzm6dbphghrgepbaxs6zrm.eu'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## main
 
+ENHANCEMENTS:
+
+- **Update Data Source:** `dnsimple_certificate` has been updated to have a stable ID. (dnsimple/terraform-provider-dnsimple#222)
+
 ## 1.5.0
 
 ENHANCEMENTS:

--- a/internal/framework/datasources/certificate_data_source.go
+++ b/internal/framework/datasources/certificate_data_source.go
@@ -149,7 +149,7 @@ func (d *CertificateDataSource) Read(ctx context.Context, req datasource.ReadReq
 		data.ServerCertificate = types.StringValue(response.Data.ServerCertificate)
 		data.RootCertificate = types.StringValue(response.Data.RootCertificate)
 		chain, diag := types.ListValueFrom(ctx, types.StringType, response.Data.IntermediateCertificates)
-		if err != nil {
+		if diag.HasError() {
 			resp.Diagnostics.Append(diag...)
 			return
 		}

--- a/internal/framework/datasources/certificate_data_source.go
+++ b/internal/framework/datasources/certificate_data_source.go
@@ -2,7 +2,10 @@ package datasources
 
 import (
 	"context"
+	"crypto/sha1"
+	"encoding/hex"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/datasource/timeouts"
@@ -166,7 +169,7 @@ func (d *CertificateDataSource) Read(ctx context.Context, req datasource.ReadReq
 		}
 
 		data.PrivateKey = types.StringValue(response.Data.PrivateKey)
-		data.Id = types.StringValue(time.Now().UTC().String())
+		data.Id = types.StringValue(idFromCertificateChain(data.ServerCertificate.ValueString(), data.RootCertificate.ValueString(), response.Data.IntermediateCertificates))
 
 		// Save data into Terraform state
 		resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -226,4 +229,19 @@ func tryToConvergeCertificate(ctx context.Context, data *CertificateDataSourceMo
 	}
 
 	return CertificateConverged, nil
+}
+
+// idFromCertificateChain generates a SHA1 hash from the certificate chain.
+func idFromCertificateChain(ServerCertificate, rootCertificate string, intermediateCertificateChain []string) string {
+	// Concatenate all certificates into a single string
+	certChain := ServerCertificate + rootCertificate + strings.Join(intermediateCertificateChain, "")
+
+	// Create a new SHA1 hash.
+	h := sha1.New()
+
+	// Write the certificate chain string to the hash.
+	h.Write([]byte(certChain))
+	hashedCertChain := hex.EncodeToString(h.Sum(nil))
+
+	return hashedCertChain
 }

--- a/internal/framework/datasources/certificate_data_source_test.go
+++ b/internal/framework/datasources/certificate_data_source_test.go
@@ -28,6 +28,14 @@ func TestAccCertificateDataSource(t *testing.T) {
 					resource.TestCheckResourceAttr("data.dnsimple_certificate.test", "certificate_id", certificateId),
 				),
 			},
+			{
+				Config: testAccCertificateDataSourceConfig(domain, certificateId),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.dnsimple_certificate.test", "domain", domain),
+					resource.TestCheckResourceAttr("data.dnsimple_certificate.test", "certificate_id", certificateId),
+				),
+				ExpectNonEmptyPlan: false,
+			},
 		},
 	})
 }


### PR DESCRIPTION
This PR computes the ID for the **dnsimple_certificate** data source using the entire certificate chain. This ensures that if the chain is updated users can act upon the change.

Fixes https://github.com/dnsimple/terraform-provider-dnsimple/issues/208