### PR TITLE
Fixes CI / Acceptance Tests (by updating registrant_contact_id)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,15 +70,15 @@ jobs:
         include:
           - terraform: '1.3.*'
             domain: 'dnsimple-3-0-terraform.bio'
-            registrant_contact_id: 10854
+            registrant_contact_id: 14323
             registrant_change_domain: 'dnsimple-tf-ci-1.eu'
           - terraform: '1.10.*'
             domain: 'dnsimple-3-1-terraform.bio'
-            registrant_contact_id: 10169
+            registrant_contact_id: 14323
             registrant_change_domain: 'dnsimple-tf-ci-2.eu'
           - terraform: '1.11.*'
             domain: 'dnsimple-3-2-terraform.bio'
-            registrant_contact_id: 10854
+            registrant_contact_id: 14323
             registrant_change_domain: 'dnsimple-tf-ci-3.eu'
     steps:
       - uses: actions/checkout@v4

--- a/tools/sweep/main.go
+++ b/tools/sweep/main.go
@@ -148,7 +148,7 @@ func cleanupDomains(ctx context.Context, dnsimpleClient *dnsimple.Client, accoun
 	cleanupEnabled := os.Getenv("DNSIMPLE_CLEANUP_DOMAINS")
 
 	if cleanupEnabled != "true" {
-		fmt.Println("Skipping domain cleanup as DNSIMPLE_CLEANUP_DOMAIN is not set")
+		fmt.Println("Skipping domain cleanup as DNSIMPLE_CLEANUP_DOMAINS is not set")
 		return
 	}
 


### PR DESCRIPTION
Fixes https://github.com/dnsimple/terraform-provider-dnsimple/issues/271

This PR is simply to update the `registrant_contact_id` in test.yml according to the new DNSimple Sandbox account created to host the domains used in the CI test suite.

# Tasklist
- https://github.com/dnsimple/terraform-provider-dnsimple/issues/271#issuecomment-2884416870