### PR TITLE
Feat: Remove dnsimple_zone data source deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## main
 
+- The `dnsimple_zone` data source is no longer deprecated and will not be removed in a future release.
+
 ## 1.9.1
 
 ENHANCEMENTS:
@@ -9,7 +11,7 @@ ENHANCEMENTS:
 - Bump golang.org/x/net from 0.37.0 to 0.38.0 (#269)
 - make: Update .PHONY
 
-NOTES: 
+NOTES:
 
 - Delete CODEOWNERS
 - Remove unnecessary gitignore entries

--- a/docs/data-sources/zone.md
+++ b/docs/data-sources/zone.md
@@ -6,8 +6,6 @@ page_title: "DNSimple: dnsimple_zone"
 
 Get information about a DNSimple zone.
 
-!> Data source is getting deprecated in favor of [`dnsimple\_zone`](../resources/zone.md) resource.
-
 # Example Usage
 
 Get zone:

--- a/internal/framework/datasources/zone_data_source.go
+++ b/internal/framework/datasources/zone_data_source.go
@@ -38,7 +38,6 @@ func (d *ZoneDataSource) Schema(ctx context.Context, req datasource.SchemaReques
 	resp.Schema = schema.Schema{
 		// This description is used by the documentation generator and the language server.
 		MarkdownDescription: "DNSimple zone data source",
-		DeprecationMessage:  "This data source is deprecated. Please use the dnsimple_zone resource instead.",
 
 		Attributes: map[string]schema.Attribute{
 			"id": common.IDInt64Attribute(),


### PR DESCRIPTION
This removes the deprecation notice since there are some valid use cases for the data source.

Closes https://github.com/dnsimple/terraform-provider-dnsimple/issues/272
