### PR TITLE
Fix dnsimple_ds_record incorrect attribute name key_tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## unreleased
+
+BUG FIXES:
+
+- resource/`dnsimple_ds_record`: Fix attribute name from `keytag` to `key_tag` to match documentation and Terraform naming conventions (#321)
+
 ## 2.0.0 - 2025-12-15
 
 BREAKING CHANGES:

--- a/internal/framework/resources/domain_ds_record_resource.go
+++ b/internal/framework/resources/domain_ds_record_resource.go
@@ -42,7 +42,7 @@ type DsRecordResourceModel struct {
 	Algorithm  types.String `tfsdk:"algorithm"`
 	Digest     types.String `tfsdk:"digest"`
 	DigestType types.String `tfsdk:"digest_type"`
-	Keytag     types.String `tfsdk:"keytag"`
+	Keytag     types.String `tfsdk:"key_tag"`
 	PublicKey  types.String `tfsdk:"public_key"`
 	CreatedAt  types.String `tfsdk:"created_at"`
 	UpdatedAt  types.String `tfsdk:"updated_at"`
@@ -82,7 +82,7 @@ func (r *DsRecordResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
-			"keytag": schema.StringAttribute{
+			"key_tag": schema.StringAttribute{
 				Optional: true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),

--- a/internal/framework/resources/domain_ds_record_resource_test.go
+++ b/internal/framework/resources/domain_ds_record_resource_test.go
@@ -31,7 +31,7 @@ func TestAccDomainDsRecordResource(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "algorithm", "8"),
 					resource.TestCheckResourceAttr(resourceName, "digest", "C3D49CB83734B22CF3EF9A193B94302FA3BB68013E3E149786D40CDC1BBACD93"),
 					resource.TestCheckResourceAttr(resourceName, "digest_type", "2"),
-					resource.TestCheckResourceAttr(resourceName, "keytag", "51301"),
+					resource.TestCheckResourceAttr(resourceName, "key_tag", "51301"),
 					resource.TestCheckResourceAttr(resourceName, "public_key", "AwEAAd4gdAYAeCnAsYYStm/eWd6uRn5XvT14D9DDM9TbmCvLKCuRA6WYz7suLAziJ5hvk2I7aTOVK8Wd1fDmVxHXGg0Jd6P2+GQpg7AGghD+oLeg0I7AesSIKO3o1ffr58x6iIsxVZ+fcC7G6vdr/d8oIJ/SZdAvghQnCNmCm49HLoN6bWJWNJIXzmxFrptvfgfB4B+PVzbquZrJ0W10KrD394U="),
 					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
 					resource.TestCheckResourceAttrSet(resourceName, "updated_at"),
@@ -94,7 +94,7 @@ resource "dnsimple_ds_record" "test" {
 	algorithm = "8"
 	digest = "C3D49CB83734B22CF3EF9A193B94302FA3BB68013E3E149786D40CDC1BBACD93"
 	digest_type = "2"
-	keytag = "51301"
+	key_tag = "51301"
 	public_key = "AwEAAd4gdAYAeCnAsYYStm/eWd6uRn5XvT14D9DDM9TbmCvLKCuRA6WYz7suLAziJ5hvk2I7aTOVK8Wd1fDmVxHXGg0Jd6P2+GQpg7AGghD+oLeg0I7AesSIKO3o1ffr58x6iIsxVZ+fcC7G6vdr/d8oIJ/SZdAvghQnCNmCm49HLoN6bWJWNJIXzmxFrptvfgfB4B+PVzbquZrJ0W10KrD394U="
 }`, domainName)
 }


### PR DESCRIPTION
The docs and code incorrectly referenced `key_tag`. The correct version is `keytag`:

- https://developer.dnsimple.com/v2/domains/dnssec/#listDomainDelegationSignerRecords
- https://github.com/dnsimple/dnsimple-go/blob/1ae027e1f8856781f387b57c3c0d4c068c23ed26/dnsimple/domains_delegation_signer_records.go#L15

Fixes https://github.com/dnsimple/terraform-provider-dnsimple/issues/321