### PR TITLE
fix: registeredDomain failing on repeated contact_id updates

### DIFF
--- a/internal/framework/resources/registered_domain/resource_test.go
+++ b/internal/framework/resources/registered_domain/resource_test.go
@@ -142,6 +142,51 @@ func TestAccRegisteredDomainResource_RegistrantChange_WithExtendedAttrs(t *testi
 	})
 }
 
+func TestAccRegisteredDomainResource_RepeatedRegistrantChange(t *testing.T) {
+	domainName := os.Getenv("DNSIMPLE_REGISTRANT_CHANGE_DOMAIN")
+	contactID := os.Getenv("DNSIMPLE_REGISTRANT_CHANGE_CONTACT_ID")
+	contactID2 := os.Getenv("DNSIMPLE_REGISTRANT_CHANGE_CONTACT_ID_2")
+	resourceName := "dnsimple_registered_domain.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckRepeatedRegistrantChange(t) },
+		ProtoV6ProviderFactories: test_utils.TestAccProtoV6ProviderFactories(),
+		CheckDestroy:             testAccCheckRegisteredDomainRegistrantChangeDestroy,
+		Steps: []resource.TestStep{
+			{
+				// Import the existing domain
+				ResourceName:       resourceName,
+				Config:             testAccRegisteredDomainResourceConfig(domainName, "1234"),
+				ImportStateId:      domainName,
+				ImportState:        true,
+				ImportStateVerify:  false,
+				ImportStatePersist: true,
+			},
+			{
+				// First contact_id change
+				Config: testAccRegisteredDomainResourceConfig(domainName, contactID),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", domainName),
+					resource.TestCheckResourceAttrSet(resourceName, "registrant_change.id"),
+					resource.TestCheckResourceAttr(resourceName, "registrant_change.contact_id", contactID),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+			{
+				// Second contact_id change - previously failed with:
+				// "unexpected unknown property value for registrantChange"
+				Config: testAccRegisteredDomainResourceConfig(domainName, contactID2),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", domainName),
+					resource.TestCheckResourceAttrSet(resourceName, "registrant_change.id"),
+					resource.TestCheckResourceAttr(resourceName, "registrant_change.contact_id", contactID2),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func TestAccRegisteredDomainResource_WithOptions(t *testing.T) {
 	domainName := utils.RandomName("com", "options")
 	contactID := os.Getenv("DNSIMPLE_CONTACT_ID")
@@ -214,6 +259,13 @@ func testAccPreCheckRegistrantChange(t *testing.T) {
 	}
 	if os.Getenv("DNSIMPLE_REGISTRANT_CHANGE_DOMAIN") == "" {
 		t.Fatal("DNSIMPLE_REGISTRANT_CHANGE_DOMAIN must be set for acceptance tests")
+	}
+}
+
+func testAccPreCheckRepeatedRegistrantChange(t *testing.T) {
+	testAccPreCheckRegistrantChange(t)
+	if os.Getenv("DNSIMPLE_REGISTRANT_CHANGE_CONTACT_ID_2") == "" {
+		t.Fatal("DNSIMPLE_REGISTRANT_CHANGE_CONTACT_ID_2 must be set for acceptance tests")
 	}
 }
 

--- a/internal/framework/resources/registered_domain/schema.go
+++ b/internal/framework/resources/registered_domain/schema.go
@@ -5,8 +5,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -150,16 +148,10 @@ func (r *RegisteredDomainResource) Schema(_ context.Context, _ resource.SchemaRe
 					"contact_id": schema.Int64Attribute{
 						MarkdownDescription: "DNSimple contact ID for which the registrant change is being performed",
 						Computed:            true,
-						PlanModifiers: []planmodifier.Int64{
-							int64planmodifier.RequiresReplace(),
-						},
 					},
 					"domain_id": schema.StringAttribute{
 						MarkdownDescription: "DNSimple domain ID for which the registrant change is being performed",
 						Computed:            true,
-						PlanModifiers: []planmodifier.String{
-							stringplanmodifier.RequiresReplace(),
-						},
 					},
 					"state": schema.StringAttribute{
 						MarkdownDescription: "State of the registrant change",
@@ -173,9 +165,6 @@ func (r *RegisteredDomainResource) Schema(_ context.Context, _ resource.SchemaRe
 						MarkdownDescription: "Extended attributes for the registrant change",
 						ElementType:         types.StringType,
 						Computed:            true,
-						PlanModifiers: []planmodifier.Map{
-							mapplanmodifier.RequiresReplaceIfConfigured(),
-						},
 					},
 					"registry_owner_change": schema.BoolAttribute{
 						MarkdownDescription: "True if the registrant change will result in a registry owner change",
@@ -185,6 +174,9 @@ func (r *RegisteredDomainResource) Schema(_ context.Context, _ resource.SchemaRe
 						MarkdownDescription: "Date when the registrant change lock was lifted for the domain",
 						Computed:            true,
 					},
+				},
+				PlanModifiers: []planmodifier.Object{
+					objectplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"timeouts": schema.SingleNestedAttribute{

--- a/internal/framework/resources/registered_domain/update.go
+++ b/internal/framework/resources/registered_domain/update.go
@@ -156,7 +156,8 @@ func (r *RegisteredDomainResource) Update(ctx context.Context, req resource.Upda
 				return
 			}
 		}
-		// Create a new registrant change (either no previous change exists or previous one is already completed)
+		// Pending registrant change has been converged or no pending change exists.
+		// Always create a new registrant change when contact_id differs.
 		createRegistrantChange(ctx, planData, r, resp)
 	} else if !registrantChange.Id.IsNull() && registrantChange.State.ValueString() != consts.RegistrantChangeStateCompleted {
 		registrantChangeResponse, err = r.config.Client.Registrar.GetRegistrantChange(ctx, r.config.AccountID, int(registrantChange.Id.ValueInt64()))

--- a/internal/framework/resources/registered_domain/update.go
+++ b/internal/framework/resources/registered_domain/update.go
@@ -117,7 +117,7 @@ func (r *RegisteredDomainResource) Update(ctx context.Context, req resource.Upda
 
 	var registrantChangeResponse *dnsimple.RegistrantChangeResponse
 	if planData.ContactId.ValueInt64() != stateData.ContactId.ValueInt64() {
-		if !registrantChange.Id.IsNull() {
+		if !registrantChange.Id.IsNull() && registrantChange.State.ValueString() != consts.RegistrantChangeStateCompleted {
 			convergenceState, _ := tryToConvergeRegistrantChange(ctx, planData, &resp.Diagnostics, r, int(registrantChange.Id.ValueInt64()))
 			if convergenceState == RegistrantChangeFailed {
 				// Response is already populated with the error we can safely return
@@ -155,11 +155,9 @@ func (r *RegisteredDomainResource) Update(ctx context.Context, req resource.Upda
 				)
 				return
 			}
-
-		} else {
-			// Create a new registrant change and handle any errors
-			createRegistrantChange(ctx, planData, r, resp)
 		}
+		// Create a new registrant change (either no previous change exists or previous one is already completed)
+		createRegistrantChange(ctx, planData, r, resp)
 	} else if !registrantChange.Id.IsNull() && registrantChange.State.ValueString() != consts.RegistrantChangeStateCompleted {
 		registrantChangeResponse, err = r.config.Client.Registrar.GetRegistrantChange(ctx, r.config.AccountID, int(registrantChange.Id.ValueInt64()))
 		if err != nil {


### PR DESCRIPTION
### What
Fixes an issue where updating `contact_id` on a `dnsimple_registered_domain` succeeds on the initial change,
but fails on subsequent updates with:
```
error: unexpected unknown property value for "registrantChange"
```

### Why
When a domain’s registrant contact is changed for the first time, the update completes successfully and a
`registrantChange` object is persisted in state.

On subsequent `contact_id` updates, the provider may encounter an **unknown value** for the
`registrantChange` attribute during planning, which causes the update to fail. 
```
dnsimple:index:RegisteredDomain ... updating [diff: ~contactId]
error: unexpected unknown property value for "registrantChange"
```
This happens because:
- The `registrant_change` object did not preserve its prior state when its value was unknown during planning
- The update logic attempted to converge an already completed registrant change instead of creating a new one
- Several nested attributes were marked with `RequiresReplace()` despite representing historical
  registrant change data rather than the domain itself


This prevents repeated registrant contact changes from being applied reliably.

### How
**schema.go**
- Added `objectplanmodifier.UseStateForUnknown()` to the `registrant_change` attribute to preserve the state value during planning
- Removed `RequiresReplace()` from `contact_id` and `domain_id` nested attributes
- Removed `RequiresReplaceIfConfigured()` from `extended_attributes`

**update.go**
- Updated the convergence logic to only attempt convergence for **pending** registrant changes
- Always create a new registrant change when `contact_id` differs, even if a previous change exists in a completed state