### PR TITLE
fix: contact phone and fax import when values are empty

### DIFF
--- a/internal/framework/resources/contact_resource.go
+++ b/internal/framework/resources/contact_resource.go
@@ -337,7 +337,13 @@ func (r *ContactResource) updateModelFromAPIResponse(contact *dnsimple.Contact, 
 	data.PostalCode = types.StringValue(contact.PostalCode)
 	data.Country = types.StringValue(contact.Country)
 	data.PhoneNormalized = types.StringValue(contact.Phone)
+	if data.Phone.IsNull() || data.Phone.IsUnknown() || data.Phone.ValueString() == "" {
+		data.Phone = types.StringValue(contact.Phone)
+	}
 	data.FaxNormalized = types.StringValue(contact.Fax)
+	if data.Fax.IsNull() || data.Fax.IsUnknown() || data.Fax.ValueString() == "" {
+		data.Fax = types.StringValue(contact.Fax)
+	}
 	data.Email = types.StringValue(contact.Email)
 	data.CreatedAt = types.StringValue(contact.CreatedAt)
 	data.UpdatedAt = types.StringValue(contact.UpdatedAt)


### PR DESCRIPTION
**What**
Fixes contact phone and fax fields not being populated during import or refresh when the current state value is empty or unknown.

**Why**
When importing contacts, the API returns values for phone and fax, and also provides `phone_normalized` and `fax_normalized`.
However, the provider only populated the normalized fields, while `phone` and `fax` could remain empty in state.
This caused an extra update right after import.

**How**
During contact read:
always set `phone_normalized` and `fax_normalized` from the API response (contact.Phone / contact.Fax).
if `phone` and/or `fax` is empty, backfill it from the same API value (contact.Phone / contact.Fax) to avoid a post-import update