### PR TITLE
Better handle long-running asynchronous domain registrations

### DIFF
--- a/internal/framework/resources/registered_domain/common.go
+++ b/internal/framework/resources/registered_domain/common.go
@@ -182,15 +182,15 @@ func (r *RegisteredDomainResource) updateModelFromAPIResponsePartialCreate(ctx c
 	if domain != nil {
 		data.Id = types.Int64Value(domain.ID)
 
-		if data.AutoRenewEnabled.IsNull() {
+		if data.AutoRenewEnabled.IsNull() || data.AutoRenewEnabled.IsUnknown() {
 			data.AutoRenewEnabled = types.BoolValue(domain.AutoRenew)
 		}
 
-		if data.WhoisPrivacyEnabled.IsNull() {
+		if data.WhoisPrivacyEnabled.IsNull() || data.WhoisPrivacyEnabled.IsUnknown() {
 			data.WhoisPrivacyEnabled = types.BoolValue(domain.PrivateWhois)
 		}
 
-		if data.Trustee.IsNull() {
+		if data.Trustee.IsNull() || data.Trustee.IsUnknown() {
 			data.Trustee = types.BoolValue(domain.Trustee)
 		}
 
@@ -203,6 +203,7 @@ func (r *RegisteredDomainResource) updateModelFromAPIResponsePartialCreate(ctx c
 
 	data.DNSSECEnabled = types.BoolValue(false)
 	data.TransferLockEnabled = types.BoolValue(false)
+	data.RegistrantChange = types.ObjectNull(common.RegistrantChangeAttrType)
 
 	return nil
 }

--- a/internal/framework/resources/registered_domain/common_test.go
+++ b/internal/framework/resources/registered_domain/common_test.go
@@ -1,0 +1,153 @@
+package registered_domain
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dnsimple/dnsimple-go/v9/dnsimple"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/terraform-providers/terraform-provider-dnsimple/internal/framework/common"
+)
+
+func TestUpdateModelFromAPIResponsePartialCreate(t *testing.T) {
+	t.Parallel()
+
+	domain := &dnsimple.Domain{
+		ID:           123,
+		AccountID:    456,
+		Name:         "example.com.br",
+		UnicodeName:  "example.com.br",
+		State:        "hosted",
+		AutoRenew:    false,
+		PrivateWhois: false,
+		ExpiresAt:    "2027-05-11T00:00:00Z",
+		Trustee:      true,
+	}
+
+	domainRegistration := &dnsimple.DomainRegistration{
+		ID:     789,
+		State:  "registering",
+		Period: 1,
+	}
+
+	t.Run("sets unknown auto_renew_enabled to known value", func(t *testing.T) {
+		t.Parallel()
+		r := &RegisteredDomainResource{}
+		data := &RegisteredDomainResourceModel{
+			AutoRenewEnabled:    types.BoolUnknown(),
+			WhoisPrivacyEnabled: types.BoolUnknown(),
+			Trustee:             types.BoolUnknown(),
+		}
+
+		diags := r.updateModelFromAPIResponsePartialCreate(context.Background(), data, domainRegistration, domain)
+		assert.Nil(t, diags)
+		assert.False(t, data.AutoRenewEnabled.IsUnknown(), "auto_renew_enabled should not be unknown")
+		assert.Equal(t, false, data.AutoRenewEnabled.ValueBool())
+	})
+
+	t.Run("sets unknown whois_privacy_enabled to known value", func(t *testing.T) {
+		t.Parallel()
+		r := &RegisteredDomainResource{}
+		data := &RegisteredDomainResourceModel{
+			AutoRenewEnabled:    types.BoolUnknown(),
+			WhoisPrivacyEnabled: types.BoolUnknown(),
+			Trustee:             types.BoolUnknown(),
+		}
+
+		diags := r.updateModelFromAPIResponsePartialCreate(context.Background(), data, domainRegistration, domain)
+		assert.Nil(t, diags)
+		assert.False(t, data.WhoisPrivacyEnabled.IsUnknown(), "whois_privacy_enabled should not be unknown")
+		assert.Equal(t, false, data.WhoisPrivacyEnabled.ValueBool())
+	})
+
+	t.Run("sets unknown trustee to known value", func(t *testing.T) {
+		t.Parallel()
+		r := &RegisteredDomainResource{}
+		data := &RegisteredDomainResourceModel{
+			AutoRenewEnabled:    types.BoolUnknown(),
+			WhoisPrivacyEnabled: types.BoolUnknown(),
+			Trustee:             types.BoolUnknown(),
+		}
+
+		diags := r.updateModelFromAPIResponsePartialCreate(context.Background(), data, domainRegistration, domain)
+		assert.Nil(t, diags)
+		assert.False(t, data.Trustee.IsUnknown(), "trustee should not be unknown")
+		assert.Equal(t, true, data.Trustee.ValueBool())
+	})
+
+	t.Run("preserves user-specified values", func(t *testing.T) {
+		t.Parallel()
+		r := &RegisteredDomainResource{}
+		data := &RegisteredDomainResourceModel{
+			AutoRenewEnabled:    types.BoolValue(true),
+			WhoisPrivacyEnabled: types.BoolValue(true),
+			Trustee:             types.BoolValue(false),
+		}
+
+		diags := r.updateModelFromAPIResponsePartialCreate(context.Background(), data, domainRegistration, domain)
+		assert.Nil(t, diags)
+		assert.Equal(t, true, data.AutoRenewEnabled.ValueBool())
+		assert.Equal(t, true, data.WhoisPrivacyEnabled.ValueBool())
+		assert.Equal(t, false, data.Trustee.ValueBool())
+	})
+
+	t.Run("sets registrant_change to null", func(t *testing.T) {
+		t.Parallel()
+		r := &RegisteredDomainResource{}
+		data := &RegisteredDomainResourceModel{
+			AutoRenewEnabled:    types.BoolUnknown(),
+			WhoisPrivacyEnabled: types.BoolUnknown(),
+			Trustee:             types.BoolUnknown(),
+			RegistrantChange:    types.ObjectUnknown(common.RegistrantChangeAttrType),
+		}
+
+		diags := r.updateModelFromAPIResponsePartialCreate(context.Background(), data, domainRegistration, domain)
+		assert.Nil(t, diags)
+		assert.True(t, data.RegistrantChange.IsNull(), "registrant_change should be null")
+		assert.False(t, data.RegistrantChange.IsUnknown(), "registrant_change should not be unknown")
+	})
+
+	t.Run("sets dnssec and transfer lock to false", func(t *testing.T) {
+		t.Parallel()
+		r := &RegisteredDomainResource{}
+		data := &RegisteredDomainResourceModel{
+			AutoRenewEnabled:    types.BoolUnknown(),
+			WhoisPrivacyEnabled: types.BoolUnknown(),
+			Trustee:             types.BoolUnknown(),
+		}
+
+		diags := r.updateModelFromAPIResponsePartialCreate(context.Background(), data, domainRegistration, domain)
+		assert.Nil(t, diags)
+		assert.Equal(t, false, data.DNSSECEnabled.ValueBool())
+		assert.Equal(t, false, data.TransferLockEnabled.ValueBool())
+	})
+
+	t.Run("all values are known after partial create", func(t *testing.T) {
+		t.Parallel()
+		r := &RegisteredDomainResource{}
+		data := &RegisteredDomainResourceModel{
+			AutoRenewEnabled:    types.BoolUnknown(),
+			WhoisPrivacyEnabled: types.BoolUnknown(),
+			Trustee:             types.BoolUnknown(),
+			RegistrantChange:    types.ObjectUnknown(common.RegistrantChangeAttrType),
+		}
+
+		diags := r.updateModelFromAPIResponsePartialCreate(context.Background(), data, domainRegistration, domain)
+		assert.Nil(t, diags)
+
+		assert.False(t, data.AutoRenewEnabled.IsUnknown(), "auto_renew_enabled should be known")
+		assert.False(t, data.WhoisPrivacyEnabled.IsUnknown(), "whois_privacy_enabled should be known")
+		assert.False(t, data.Trustee.IsUnknown(), "trustee should be known")
+		assert.False(t, data.DNSSECEnabled.IsUnknown(), "dnssec_enabled should be known")
+		assert.False(t, data.TransferLockEnabled.IsUnknown(), "transfer_lock_enabled should be known")
+		assert.False(t, data.RegistrantChange.IsUnknown(), "registrant_change should be known")
+		assert.False(t, data.DomainRegistration.IsUnknown(), "domain_registration should be known")
+		assert.False(t, data.State.IsUnknown(), "state should be known")
+		assert.False(t, data.Name.IsUnknown(), "name should be known")
+		assert.False(t, data.UnicodeName.IsUnknown(), "unicode_name should be known")
+		assert.False(t, data.AccountId.IsUnknown(), "account_id should be known")
+		assert.False(t, data.ExpiresAt.IsUnknown(), "expires_at should be known")
+		assert.False(t, data.Id.IsUnknown(), "id should be known")
+	})
+}

--- a/internal/framework/resources/registered_domain/read.go
+++ b/internal/framework/resources/registered_domain/read.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/dnsimple/dnsimple-go/v9/dnsimple"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/terraform-providers/terraform-provider-dnsimple/internal/consts"
 )
 
 func (r *RegisteredDomainResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
@@ -73,28 +74,35 @@ func (r *RegisteredDomainResource) Read(ctx context.Context, req resource.ReadRe
 		return
 	}
 
-	dnssecResponse, err := r.config.Client.Domains.GetDnssec(ctx, r.config.AccountID, data.Name.ValueString())
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"failed to read DNSimple Domain DNSSEC status",
-			fmt.Sprintf("Unable to read DNSSEC status for domain '%s': %s", data.Name.ValueString(), err.Error()),
-		)
-		return
-	}
+	var dnssec *dnsimple.Dnssec
+	var transferLock *dnsimple.DomainTransferLock
 
-	transferLockResponse, err := r.config.Client.Registrar.GetDomainTransferLock(ctx, r.config.AccountID, data.Name.ValueString())
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"failed to read DNSimple Domain Transfer Lock status",
-			fmt.Sprintf("Unable to read transfer lock status for domain '%s': %s", data.Name.ValueString(), err.Error()),
-		)
-		return
+	if domainResponse.Data.State == consts.DomainStateRegistered {
+		dnssecResponse, err := r.config.Client.Domains.GetDnssec(ctx, r.config.AccountID, data.Name.ValueString())
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"failed to read DNSimple Domain DNSSEC status",
+				fmt.Sprintf("Unable to read DNSSEC status for domain '%s': %s", data.Name.ValueString(), err.Error()),
+			)
+			return
+		}
+		dnssec = dnssecResponse.Data
+
+		transferLockResponse, err := r.config.Client.Registrar.GetDomainTransferLock(ctx, r.config.AccountID, data.Name.ValueString())
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"failed to read DNSimple Domain Transfer Lock status",
+				fmt.Sprintf("Unable to read transfer lock status for domain '%s': %s", data.Name.ValueString(), err.Error()),
+			)
+			return
+		}
+		transferLock = transferLockResponse.Data
 	}
 
 	if domainRegistrationResponse == nil {
-		diags = r.updateModelFromAPIResponse(ctx, data, nil, domainResponse.Data, dnssecResponse.Data, transferLockResponse.Data)
+		diags = r.updateModelFromAPIResponse(ctx, data, nil, domainResponse.Data, dnssec, transferLock)
 	} else {
-		diags = r.updateModelFromAPIResponse(ctx, data, domainRegistrationResponse.Data, domainResponse.Data, dnssecResponse.Data, transferLockResponse.Data)
+		diags = r.updateModelFromAPIResponse(ctx, data, domainRegistrationResponse.Data, domainResponse.Data, dnssec, transferLock)
 	}
 
 	if diags != nil && diags.HasError() {

--- a/internal/framework/resources/registered_domain/resource_test.go
+++ b/internal/framework/resources/registered_domain/resource_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"regexp"
 	"strconv"
 	"testing"
 
@@ -231,6 +232,43 @@ func TestAccRegisteredDomainResource_ImportedWithDomainOnly(t *testing.T) {
 	})
 }
 
+func TestAccRegisteredDomainResource_AsyncRegistration(t *testing.T) {
+	domainName := utils.RandomName("com.br", "")[:8] + ".com.br"
+	contactID := os.Getenv("DNSIMPLE_CONTACT_ID")
+	resourceName := "dnsimple_registered_domain.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckRegisteredDomain(t) },
+		ProtoV6ProviderFactories: test_utils.TestAccProtoV6ProviderFactories(),
+		CheckDestroy:             testAccCheckRegisteredDomainResourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				// Step 1: Register a .com.br domain with trustee, which is asynchronous.
+				// The registration will not complete within the timeout, so the provider
+				// should save partial state with a warning and no errors.
+				Config: testAccRegisteredDomainResourceConfig_AsyncRegistration(domainName, contactID),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", domainName),
+					resource.TestCheckResourceAttrSet(resourceName, "domain_registration.id"),
+					resource.TestCheckResourceAttr(resourceName, "trustee", "true"),
+					resource.TestCheckResourceAttr(resourceName, "dnssec_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "transfer_lock_enabled", "false"),
+				),
+				// The plan modifier will detect the non-registered state and plan an update
+				ExpectNonEmptyPlan: true,
+			},
+			{
+				// Step 2: Re-apply with the same config. This triggers a Read (which should
+				// handle the pending registration gracefully by skipping DNSSEC/transfer lock calls),
+				// followed by an Update that attempts to converge the registration.
+				// The update will fail to converge since the domain is still registering.
+				Config:      testAccRegisteredDomainResourceConfig_AsyncRegistration(domainName, contactID),
+				ExpectError: regexp.MustCompile(`failed to converge on domain registration`),
+			},
+		},
+	})
+}
+
 func testAccPreCheckRegisteredDomain(t *testing.T) {
 	test_utils.TestAccPreCheck(t)
 	if os.Getenv("DNSIMPLE_CONTACT_ID") == "" {
@@ -340,6 +378,22 @@ resource "dnsimple_registered_domain" "test" {
 	dnssec_enabled = %[5]t
 	transfer_lock_enabled = %[6]t
 }`, domainName, contactId, withAutoRenew, withWhoisPrivacy, withDNSSEC, withTransferLock)
+}
+
+func testAccRegisteredDomainResourceConfig_AsyncRegistration(domainName, contactId string) string {
+	return fmt.Sprintf(`
+resource "dnsimple_registered_domain" "test" {
+	name = %[1]q
+	contact_id = %[2]q
+
+	trustee = true
+
+	timeouts = {
+		create = "20s"
+		update = "30s"
+		delete = "30s"
+	}
+}`, domainName, contactId)
 }
 
 func testAccRegisteredDomainResourceConfig_WithTrustee(domainName, contactId string) string {

--- a/internal/framework/resources/registered_domain/resource_test.go
+++ b/internal/framework/resources/registered_domain/resource_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"regexp"
 	"strconv"
 	"testing"
 
@@ -257,14 +256,6 @@ func TestAccRegisteredDomainResource_AsyncRegistration(t *testing.T) {
 				// The plan modifier will detect the non-registered state and plan an update
 				ExpectNonEmptyPlan: true,
 			},
-			{
-				// Step 2: Re-apply with the same config. This triggers a Read (which should
-				// handle the pending registration gracefully by skipping DNSSEC/transfer lock calls),
-				// followed by an Update that attempts to converge the registration.
-				// The update will fail to converge since the domain is still registering.
-				Config:      testAccRegisteredDomainResourceConfig_AsyncRegistration(domainName, contactID),
-				ExpectError: regexp.MustCompile(`failed to converge on domain registration`),
-			},
 		},
 	})
 }
@@ -389,8 +380,8 @@ resource "dnsimple_registered_domain" "test" {
 	trustee = true
 
 	timeouts = {
-		create = "1m"
-		update = "1m"
+		create = "20s"
+		update = "20s"
 		delete = "30s"
 	}
 }`, domainName, contactId)

--- a/internal/framework/resources/registered_domain/resource_test.go
+++ b/internal/framework/resources/registered_domain/resource_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"regexp"
 	"strconv"
 	"testing"
 
@@ -232,7 +233,7 @@ func TestAccRegisteredDomainResource_ImportedWithDomainOnly(t *testing.T) {
 }
 
 func TestAccRegisteredDomainResource_AsyncRegistration(t *testing.T) {
-	domainName := utils.RandomName("com.br", "")[:8] + ".com.br"
+	domainName := utils.RandomName("com.br", "")[:16] + ".com.br"
 	contactID := os.Getenv("DNSIMPLE_CONTACT_ID")
 	resourceName := "dnsimple_registered_domain.test"
 
@@ -255,6 +256,14 @@ func TestAccRegisteredDomainResource_AsyncRegistration(t *testing.T) {
 				),
 				// The plan modifier will detect the non-registered state and plan an update
 				ExpectNonEmptyPlan: true,
+			},
+			{
+				// Step 2: Re-apply with the same config. This triggers a Read (which should
+				// handle the pending registration gracefully by skipping DNSSEC/transfer lock calls),
+				// followed by an Update that attempts to converge the registration.
+				// The update will fail to converge since the domain is still registering.
+				Config:      testAccRegisteredDomainResourceConfig_AsyncRegistration(domainName, contactID),
+				ExpectError: regexp.MustCompile(`failed to converge on domain registration`),
 			},
 		},
 	})

--- a/internal/framework/resources/registered_domain/resource_test.go
+++ b/internal/framework/resources/registered_domain/resource_test.go
@@ -389,8 +389,8 @@ resource "dnsimple_registered_domain" "test" {
 	trustee = true
 
 	timeouts = {
-		create = "10s"
-		update = "10s"
+		create = "1m"
+		update = "1m"
 		delete = "30s"
 	}
 }`, domainName, contactId)

--- a/internal/framework/resources/registered_domain/resource_test.go
+++ b/internal/framework/resources/registered_domain/resource_test.go
@@ -389,8 +389,8 @@ resource "dnsimple_registered_domain" "test" {
 	trustee = true
 
 	timeouts = {
-		create = "20s"
-		update = "30s"
+		create = "10s"
+		update = "10s"
 		delete = "30s"
 	}
 }`, domainName, contactId)


### PR DESCRIPTION
Fix `dnsimple_registered_domain` returning unknown values after apply when domain registration is long-running and asynchronous, which caused the resource to be tainted. Also, skip DNSSEC and transfer lock API calls during Read for domains that are not yet registered.

Addresses https://github.com/dnsimple/terraform-provider-dnsimple/issues/353

## QA

(Optional for reviewers)

1. Build the provider locally

```bash
cd /path/to/terraform-provider-dnsimple # where you checked out this repository
go build -o terraform-provider-dnsimple
```

2. Configure provider development override

**Temporarily** create or update `~/.terraformrc`:

```hcl
provider_installation {
  dev_overrides {
    "dnsimple/dnsimple" = "/path/to/terraform-provider-dnsimple"
  }
  direct {}
}
```

3. Test registering a domain with trustee

```bash
export DNSIMPLE_TOKEN="your-sandbox-token"
export DNSIMPLE_ACCOUNT="your-account-id"
export DNSIMPLE_DOMAIN="an-existing-domain.com"
```

Create a directory with a `main.tf`:

```hcl
terraform {
  required_providers {
    dnsimple = {
      source = "dnsimple/dnsimple"
    }
  }
}

provider "dnsimple" {
  sandbox = true
}

resource "dnsimple_registered_domain" "test" {
  name       = "my-async-domain-test.com.br"
  contact_id = YOUR_CONTACT_ID
  trustee    = true
}
```

Run:

```bash
terraform plan
terraform apply
```

Example results:

```
bash-5.2$ terraform apply
╷
│ Warning: Provider development overrides are in effect
│ 
│ The following provider development overrides are set in the CLI configuration:
│  - dnsimple/dnsimple in /path/to/terraform-provider-dnsimple
│ 
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵
dnsimple_registered_domain.test: Refreshing state... [name=my-trustee-test-domain4.com.br]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # dnsimple_registered_domain.test will be updated in-place
  ~ resource "dnsimple_registered_domain" "test" {
      ~ account_id            = 1640 -> (known after apply)
      ~ auto_renew_enabled    = false -> (known after apply)
      ~ dnssec_enabled        = false -> (known after apply)
      ~ domain_registration   = {
          ~ id     = 70365 -> (known after apply)
          ~ period = 1 -> (known after apply)
          ~ state  = "registering" -> (known after apply)
        } -> (known after apply)
      ~ expires_at            = null -> (known after apply)
        id                    = 508963
        name                  = "my-trustee-test-domain4.com.br"
      + registrant_change     = (known after apply)
      ~ state                 = "hosted" -> (known after apply)
      ~ transfer_lock_enabled = false -> (known after apply)
      ~ trustee               = false -> true
      ~ unicode_name          = "my-trustee-test-domain4.com.br" -> (known after apply)
      ~ whois_privacy_enabled = false -> (known after apply)
        # (1 unchanged attribute hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

dnsimple_registered_domain.test: Modifying... [name=my-trustee-test-domain4.com.br]
dnsimple_registered_domain.test: Still modifying... [name=my-trustee-test-domain4.com.br, 00m10s elapsed]
dnsimple_registered_domain.test: Still modifying... [name=my-trustee-test-domain4.com.br, 00m20s elapsed]
dnsimple_registered_domain.test: Still modifying... [name=my-trustee-test-domain4.com.br, 00m30s elapsed]
dnsimple_registered_domain.test: Still modifying... [name=my-trustee-test-domain4.com.br, 00m40s elapsed]
╷
│ Error: failed to converge on domain registration
│ 
│   with dnsimple_registered_domain.test,
│   on main.tf line 13, in resource "dnsimple_registered_domain" "test":
│   13: resource "dnsimple_registered_domain" "test" {
│ 
│ domain registration is not complete, current state: registering. You can try to run terraform again to try and converge the domain registration
╵
bash-5.2$ terraform apply
╷
│ Warning: Provider development overrides are in effect
│ 
│ The following provider development overrides are set in the CLI configuration:
│  - dnsimple/dnsimple in /path/to/terraform-provider-dnsimple
│ 
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵
dnsimple_registered_domain.test: Refreshing state... [name=my-trustee-test-domain4.com.br]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # dnsimple_registered_domain.test will be updated in-place
  ~ resource "dnsimple_registered_domain" "test" {
      ~ account_id            = 1640 -> (known after apply)
      ~ auto_renew_enabled    = false -> (known after apply)
      ~ dnssec_enabled        = false -> (known after apply)
      ~ domain_registration   = {
          ~ id     = 70365 -> (known after apply)
          ~ period = 1 -> (known after apply)
          ~ state  = "registering" -> (known after apply)
        } -> (known after apply)
      ~ expires_at            = null -> (known after apply)
        id                    = 508963
        name                  = "my-trustee-test-domain4.com.br"
      + registrant_change     = (known after apply)
      ~ state                 = "hosted" -> (known after apply)
      ~ transfer_lock_enabled = false -> (known after apply)
      ~ trustee               = false -> true
      ~ unicode_name          = "my-trustee-test-domain4.com.br" -> (known after apply)
      ~ whois_privacy_enabled = false -> (known after apply)
        # (1 unchanged attribute hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

dnsimple_registered_domain.test: Modifying... [name=my-trustee-test-domain4.com.br]
dnsimple_registered_domain.test: Still modifying... [name=my-trustee-test-domain4.com.br, 00m10s elapsed]
dnsimple_registered_domain.test: Still modifying... [name=my-trustee-test-domain4.com.br, 00m20s elapsed]
dnsimple_registered_domain.test: Still modifying... [name=my-trustee-test-domain4.com.br, 00m30s elapsed]
dnsimple_registered_domain.test: Still modifying... [name=my-trustee-test-domain4.com.br, 00m40s elapsed]
╷
│ Error: failed to converge on domain registration
│ 
│   with dnsimple_registered_domain.test,
│   on main.tf line 13, in resource "dnsimple_registered_domain" "test":
│   13: resource "dnsimple_registered_domain" "test" {
│ 
│ domain registration is not complete, current state: registering. You can try to run terraform again to try and converge the domain registration
╵
```