### PR TITLE
Gracefully handle expired domains during refresh

### DIFF
--- a/internal/framework/resources/domain_delegation_resource.go
+++ b/internal/framework/resources/domain_delegation_resource.go
@@ -137,6 +137,12 @@ func (r *DomainDelegationResource) Read(ctx context.Context, req resource.ReadRe
 
 	response, err := r.config.Client.Registrar.GetDomainDelegation(ctx, r.config.AccountID, data.Domain.ValueString())
 	if err != nil {
+		if utils.IsDomainNotRegisteredOrExpiredError(err) {
+			tflog.Warn(ctx, "removing domain delegation from state because the domain is no longer registered or has expired", map[string]interface{}{"domain": data.Domain.ValueString()})
+			resp.State.RemoveResource(ctx)
+			return
+		}
+
 		resp.Diagnostics.AddError(
 			"failed to read DNSimple Domain Delegation",
 			fmt.Sprintf("Unable to read domain delegation for domain '%s': %s", data.Domain.ValueString(), err.Error()),

--- a/internal/framework/resources/registered_domain/read.go
+++ b/internal/framework/resources/registered_domain/read.go
@@ -7,7 +7,9 @@ import (
 
 	"github.com/dnsimple/dnsimple-go/v9/dnsimple"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/terraform-providers/terraform-provider-dnsimple/internal/consts"
+	"github.com/terraform-providers/terraform-provider-dnsimple/internal/framework/utils"
 )
 
 func (r *RegisteredDomainResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
@@ -32,6 +34,12 @@ func (r *RegisteredDomainResource) Read(ctx context.Context, req resource.ReadRe
 		domainRegistrationId := strconv.Itoa(int(domainRegistration.Id.ValueInt64()))
 		domainRegistrationResponse, err = r.config.Client.Registrar.GetDomainRegistration(ctx, r.config.AccountID, data.Name.ValueString(), domainRegistrationId)
 		if err != nil {
+			if utils.IsDomainNotRegisteredOrExpiredError(err) {
+				tflog.Warn(ctx, "removing registered domain from state because the domain is no longer registered or has expired", map[string]interface{}{"domain": data.Name.ValueString()})
+				resp.State.RemoveResource(ctx)
+				return
+			}
+
 			resp.Diagnostics.AddError(
 				"failed to read DNSimple Domain Registration",
 				fmt.Sprintf("Unable to read domain registration for domain '%s' (registration ID: %d): %s", data.Name.ValueString(), domainRegistration.Id.ValueInt64(), err.Error()),
@@ -80,6 +88,12 @@ func (r *RegisteredDomainResource) Read(ctx context.Context, req resource.ReadRe
 	if domainResponse.Data.State == consts.DomainStateRegistered {
 		dnssecResponse, err := r.config.Client.Domains.GetDnssec(ctx, r.config.AccountID, data.Name.ValueString())
 		if err != nil {
+			if utils.IsDomainNotRegisteredOrExpiredError(err) {
+				tflog.Warn(ctx, "removing registered domain from state because the domain is no longer registered or has expired", map[string]interface{}{"domain": data.Name.ValueString()})
+				resp.State.RemoveResource(ctx)
+				return
+			}
+
 			resp.Diagnostics.AddError(
 				"failed to read DNSimple Domain DNSSEC status",
 				fmt.Sprintf("Unable to read DNSSEC status for domain '%s': %s", data.Name.ValueString(), err.Error()),
@@ -90,6 +104,12 @@ func (r *RegisteredDomainResource) Read(ctx context.Context, req resource.ReadRe
 
 		transferLockResponse, err := r.config.Client.Registrar.GetDomainTransferLock(ctx, r.config.AccountID, data.Name.ValueString())
 		if err != nil {
+			if utils.IsDomainNotRegisteredOrExpiredError(err) {
+				tflog.Warn(ctx, "removing registered domain from state because the domain is no longer registered or has expired", map[string]interface{}{"domain": data.Name.ValueString()})
+				resp.State.RemoveResource(ctx)
+				return
+			}
+
 			resp.Diagnostics.AddError(
 				"failed to read DNSimple Domain Transfer Lock status",
 				fmt.Sprintf("Unable to read transfer lock status for domain '%s': %s", data.Name.ValueString(), err.Error()),

--- a/internal/framework/utils/utils.go
+++ b/internal/framework/utils/utils.go
@@ -2,7 +2,9 @@ package utils
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"strings"
 	"time"
@@ -90,6 +92,25 @@ func AttributeErrorsToDiagnostics(err *dnsimple.ErrorResponse) diag.Diagnostics 
 	}
 
 	return diagnostics
+}
+
+// IsDomainNotRegisteredOrExpiredError returns true if err is a DNSimple API
+// error indicating that a registrar-level operation was rejected because the
+// domain is no longer registered at the registry (e.g. it lapsed and moved
+// past its renewal/redemption grace period). The DNSimple API surfaces this
+// as an HTTP 400 rather than a 404, so it cannot be treated as a generic
+// not-found response.
+func IsDomainNotRegisteredOrExpiredError(err error) bool {
+	var errorResponse *dnsimple.ErrorResponse
+	if !errors.As(err, &errorResponse) {
+		return false
+	}
+
+	if errorResponse.HTTPResponse == nil || errorResponse.HTTPResponse.StatusCode != http.StatusBadRequest {
+		return false
+	}
+
+	return strings.Contains(strings.ToLower(errorResponse.Message), "not registered or expired")
 }
 
 func TranslateFieldFromAPIToTerraform(field string) string {

--- a/internal/framework/utils/utils_test.go
+++ b/internal/framework/utils/utils_test.go
@@ -1,8 +1,11 @@
 package utils_test
 
 import (
+	"errors"
+	"net/http"
 	"testing"
 
+	"github.com/dnsimple/dnsimple-go/v9/dnsimple"
 	"github.com/stretchr/testify/assert"
 	"github.com/terraform-providers/terraform-provider-dnsimple/internal/framework/utils"
 )
@@ -32,6 +35,60 @@ func TestHasUnicodeChars(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.want, utils.HasUnicodeChars(tt.s))
+		})
+	}
+}
+
+func TestIsDomainNotRegisteredOrExpiredError(t *testing.T) {
+	newErrorResponse := func(statusCode int, message string) error {
+		return &dnsimple.ErrorResponse{
+			Response: dnsimple.Response{
+				HTTPResponse: &http.Response{StatusCode: statusCode},
+			},
+			Message: message,
+		}
+	}
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "matching 400 error",
+			err:  newErrorResponse(http.StatusBadRequest, "Change rejected: domain is not registered or expired"),
+			want: true,
+		},
+		{
+			name: "matching 400 error with different casing",
+			err:  newErrorResponse(http.StatusBadRequest, "Change rejected: Domain Is Not Registered Or Expired"),
+			want: true,
+		},
+		{
+			name: "unrelated 400 error",
+			err:  newErrorResponse(http.StatusBadRequest, "Validation failed"),
+			want: false,
+		},
+		{
+			name: "matching message but not a 400",
+			err:  newErrorResponse(http.StatusNotFound, "domain is not registered or expired"),
+			want: false,
+		},
+		{
+			name: "non-dnsimple error",
+			err:  errors.New("boom"),
+			want: false,
+		},
+		{
+			name: "nil error",
+			err:  nil,
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, utils.IsDomainNotRegisteredOrExpiredError(tt.err))
 		})
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #327.

The DNSimple API rejects registrar-level operations (delegation, transfer lock, registration, DNSSEC) on domains that have lapsed past their registry grace period with an HTTP 400 rather than a 404. This meant `dnsimple_registered_domain` and `dnsimple_domain_delegation` reads failed the entire `terraform plan`/`apply` during refresh instead of just dropping the resource from state, breaking the normal "remove from config" workflow once a domain expires.

- Added `utils.IsDomainNotRegisteredOrExpiredError` to detect this specific 400 response.
- `dnsimple_domain_delegation` `Read()` now removes the resource from state (with a warning) instead of erroring when this occurs.
- `dnsimple_registered_domain` `Read()` does the same for its registrar-backed calls (`GetDomainRegistration`, `GetDnssec`, `GetDomainTransferLock`).
- Added unit tests for the new helper.

## Test plan

- [x] `make test`
- [ ] Manual verification against a real expired domain (not available in this environment)