### PR TITLE
Report lapsed domains without dropping them from state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+FEATURES:
+
+- resource/`dnsimple_registered_domain`, resource/`dnsimple_domain_delegation`: Registrar calls rejected because a domain has lapsed past the registry grace period now report a warning during refresh instead of failing the whole plan. Terraform state is left as-is rather than dropping the resource, which would otherwise leave a lapsed `dnsimple_registered_domain` to be planned as a new, billable registration (#367)
+
 ## 2.1.2 - 2026-05-12
 
 BUG FIXES:

--- a/internal/framework/resources/domain_delegation_resource.go
+++ b/internal/framework/resources/domain_delegation_resource.go
@@ -138,8 +138,17 @@ func (r *DomainDelegationResource) Read(ctx context.Context, req resource.ReadRe
 	response, err := r.config.Client.Registrar.GetDomainDelegation(ctx, r.config.AccountID, data.Domain.ValueString())
 	if err != nil {
 		if utils.IsDomainNotRegisteredOrExpiredError(err) {
-			tflog.Warn(ctx, "removing domain delegation from state because the domain is no longer registered or has expired", map[string]interface{}{"domain": data.Domain.ValueString()})
-			resp.State.RemoveResource(ctx)
+			// Report without failing the refresh, and leave prior state untouched.
+			// Dropping the resource would only discard the record of the managed name
+			// servers and still leave the practitioner with an apply that cannot
+			// succeed while the domain stays unregistered.
+			tflog.Warn(ctx, "registrar call rejected because the domain is no longer registered or has expired", map[string]interface{}{"domain": data.Domain.ValueString()})
+
+			resp.Diagnostics.AddWarning(
+				fmt.Sprintf("could not refresh the delegation for %s because the domain is no longer registered", data.Domain.ValueString()),
+				fmt.Sprintf("The DNSimple API reports that '%s' is not registered or has expired, so its delegation could not be refreshed. Terraform state has been left as-is rather than dropping the resource. Renew or restore the domain to resume managing its delegation, or remove the resource from your configuration and state if you no longer want it managed. Any plan produced while the domain stays lapsed is unlikely to apply cleanly.", data.Domain.ValueString()),
+			)
+
 			return
 		}
 

--- a/internal/framework/resources/registered_domain/read.go
+++ b/internal/framework/resources/registered_domain/read.go
@@ -12,6 +12,24 @@ import (
 	"github.com/terraform-providers/terraform-provider-dnsimple/internal/framework/utils"
 )
 
+// warnDomainNoLongerRegistered reports that a registrar call was rejected because the
+// domain has lapsed, without failing the refresh. Callers return immediately afterwards,
+// which leaves prior state untouched.
+//
+// A lapsed domain must not fail the whole plan, which is the point of this handling. It
+// must not silently drop the resource from state either: Terraform plans a fresh create
+// for anything still in the configuration, and creating this resource re-registers the
+// domain, which is billable and would run unattended under `apply -auto-approve`.
+// Reporting and leaving state alone keeps the decision with the practitioner.
+func warnDomainNoLongerRegistered(ctx context.Context, domain string, resp *resource.ReadResponse) {
+	tflog.Warn(ctx, "registrar call rejected because the domain is no longer registered or has expired", map[string]interface{}{"domain": domain})
+
+	resp.Diagnostics.AddWarning(
+		fmt.Sprintf("could not refresh %s because it is no longer registered", domain),
+		fmt.Sprintf("The DNSimple API reports that '%s' is not registered or has expired, so its registrar details could not be refreshed. Terraform state has been left as-is rather than dropping the resource, which would have planned a new registration. Renew or restore the domain to resume managing it, or remove the resource from your configuration and state if you no longer want it managed. Any plan produced while the domain stays lapsed is unlikely to apply cleanly.", domain),
+	)
+}
+
 func (r *RegisteredDomainResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	var data *RegisteredDomainResourceModel
 
@@ -35,8 +53,7 @@ func (r *RegisteredDomainResource) Read(ctx context.Context, req resource.ReadRe
 		domainRegistrationResponse, err = r.config.Client.Registrar.GetDomainRegistration(ctx, r.config.AccountID, data.Name.ValueString(), domainRegistrationId)
 		if err != nil {
 			if utils.IsDomainNotRegisteredOrExpiredError(err) {
-				tflog.Warn(ctx, "removing registered domain from state because the domain is no longer registered or has expired", map[string]interface{}{"domain": data.Name.ValueString()})
-				resp.State.RemoveResource(ctx)
+				warnDomainNoLongerRegistered(ctx, data.Name.ValueString(), resp)
 				return
 			}
 
@@ -89,8 +106,7 @@ func (r *RegisteredDomainResource) Read(ctx context.Context, req resource.ReadRe
 		dnssecResponse, err := r.config.Client.Domains.GetDnssec(ctx, r.config.AccountID, data.Name.ValueString())
 		if err != nil {
 			if utils.IsDomainNotRegisteredOrExpiredError(err) {
-				tflog.Warn(ctx, "removing registered domain from state because the domain is no longer registered or has expired", map[string]interface{}{"domain": data.Name.ValueString()})
-				resp.State.RemoveResource(ctx)
+				warnDomainNoLongerRegistered(ctx, data.Name.ValueString(), resp)
 				return
 			}
 
@@ -105,8 +121,7 @@ func (r *RegisteredDomainResource) Read(ctx context.Context, req resource.ReadRe
 		transferLockResponse, err := r.config.Client.Registrar.GetDomainTransferLock(ctx, r.config.AccountID, data.Name.ValueString())
 		if err != nil {
 			if utils.IsDomainNotRegisteredOrExpiredError(err) {
-				tflog.Warn(ctx, "removing registered domain from state because the domain is no longer registered or has expired", map[string]interface{}{"domain": data.Name.ValueString()})
-				resp.State.RemoveResource(ctx)
+				warnDomainNoLongerRegistered(ctx, data.Name.ValueString(), resp)
 				return
 			}
 

--- a/internal/framework/utils/utils.go
+++ b/internal/framework/utils/utils.go
@@ -100,6 +100,17 @@ func AttributeErrorsToDiagnostics(err *dnsimple.ErrorResponse) diag.Diagnostics 
 // past its renewal/redemption grace period). The DNSimple API surfaces this
 // as an HTTP 400 rather than a 404, so it cannot be treated as a generic
 // not-found response.
+//
+// The message match was taken from a real response. Requesting the delegation of
+// a lapsed domain returns:
+//
+//	HTTP/1.1 400 Bad Request
+//	{"message":"Change rejected: domain is not registered or expired"}
+//
+// Matching on message text is unavoidable here, since the status code alone does
+// not distinguish this from any other rejected request. If the wording changes,
+// this returns false and callers fall back to reporting a hard error, so the
+// failure mode is a worse message rather than a wrong action.
 func IsDomainNotRegisteredOrExpiredError(err error) bool {
 	var errorResponse *dnsimple.ErrorResponse
 	if !errors.As(err, &errorResponse) {


### PR DESCRIPTION
Follow-up to #367, which is already on `main`.

## Problem

When a registrar call is rejected because a domain has lapsed past the registry grace period, `Read` currently calls `resp.State.RemoveResource(ctx)`. Terraform then plans a fresh **create** for anything still in the configuration.

For `dnsimple_registered_domain`, creating the resource registers the domain. That is a billable operation, and under `terraform apply -auto-approve` it runs unattended. The only signal today is `tflog.Warn`, which is invisible during a normal plan unless `TF_LOG` is set.

For `dnsimple_domain_delegation`, the removal discards the record of the managed name servers and still leaves an apply that cannot succeed while the domain stays unregistered.

## Change

Keep the non-blocking behaviour that #367 introduced, and stop removing the resource. `Read` now emits a practitioner-visible warning and returns. The framework seeds `ReadResponse.State` from the current state, so returning early leaves prior state intact: the refresh does not fail, nothing is planned for the resource, and the practitioner decides whether to renew, restore, or stop managing it.

The warning text names the domain and points at renew/restore or explicit removal.

## Also included

The doc comment on `utils.IsDomainNotRegisteredOrExpiredError` now records the API response the match is based on:

```
HTTP/1.1 400 Bad Request
{"message":"Change rejected: domain is not registered or expired"}
```

Matching on message text is required here, since the status code alone does not distinguish this case from any other rejected request. If the wording changes, the function returns false and callers fall back to the pre-existing hard error, so the failure mode is a worse message rather than a wrong action.

## Testing

- `TestAccDomainDelegationResource` passes against sandbox.
- The 400 response above was confirmed against a genuinely expired domain in sandbox.
- The matcher has unit coverage for status code, message wording, casing, and non-DNSimple errors.

The lapsed-domain path itself has no automated coverage, since that state cannot be produced on demand. This is unchanged from #367 as merged.

## Merge order

Suggested first of the four related PRs, since it corrects behaviour already released. The others are #373, #374 and #375. Each carries its own `CHANGELOG.md` entry, so expect a trivial conflict in the `## Unreleased` section for whichever merges after the first.
