### PR TITLE
Fix repeated contact_id updates on dnsimple_registered_domain

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,14 +70,17 @@ jobs:
             domain: "dnsimple-3-0-terraform.bio"
             registrant_contact_id: 14323
             registrant_change_domain: "dnsimple-tf-ci-1.eu"
+            registrant_contact_id_2: 15562
           - terraform: "1.13.*"
             domain: "dnsimple-3-1-terraform.bio"
             registrant_contact_id: 14323
             registrant_change_domain: "dnsimple-tf-ci-2.eu"
+            registrant_contact_id_2: 15561
           - terraform: "1.14.*"
             domain: "dnsimple-3-2-terraform.bio"
             registrant_contact_id: 14323
             registrant_change_domain: "dnsimple-tf-ci-3.eu"
+            registrant_contact_id_2: 15560
     steps:
       - uses: actions/checkout@v7.0.1
       - uses: actions/setup-go@v7.0.0
@@ -98,6 +101,7 @@ jobs:
           DNSIMPLE_CONTACT_ID: ${{ secrets.DNSIMPLE_CONTACT_ID }}
           DNSIMPLE_REGISTRANT_CHANGE_DOMAIN: ${{ matrix.registrant_change_domain }}
           DNSIMPLE_REGISTRANT_CHANGE_CONTACT_ID: ${{ matrix.registrant_contact_id }}
+          DNSIMPLE_REGISTRANT_CHANGE_CONTACT_ID_2: ${{ matrix.registrant_contact_id_2 }}
         run: go test -v ./internal/... -timeout 10m
         timeout-minutes: 10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ FEATURES:
 
 - resource/`dnsimple_registered_domain`, resource/`dnsimple_domain_delegation`: Registrar calls rejected because a domain has lapsed past the registry grace period now report a warning during refresh instead of failing the whole plan. Terraform state is left as-is rather than dropping the resource, which would otherwise leave a lapsed `dnsimple_registered_domain` to be planned as a new, billable registration (#367)
 
+BUG FIXES:
+
+- resource/`dnsimple_registered_domain`: Fix repeated `contact_id` updates failing after the first registrant change completed (#325)
+- resource/`dnsimple_registered_domain`: Pass the registrant change ID rather than the domain ID when re-reading a pending registrant change
+
 ## 2.1.2 - 2026-05-12
 
 BUG FIXES:

--- a/internal/framework/resources/registered_domain/common.go
+++ b/internal/framework/resources/registered_domain/common.go
@@ -422,11 +422,15 @@ func createRegistrantChange(ctx context.Context, data *RegisteredDomainResourceM
 				return
 			}
 
-			registrantChangeResponse, err = r.config.Client.Registrar.GetRegistrantChange(ctx, r.config.AccountID, int(data.Id.ValueInt64()))
+			// This takes the registrant change ID, not the domain ID. Passing
+			// data.Id here read an unrelated registrant change that happened to
+			// share the domain's numeric ID, or failed outright.
+			registrantChangeId := registrantChangeResponse.Data.Id
+			registrantChangeResponse, err = r.config.Client.Registrar.GetRegistrantChange(ctx, r.config.AccountID, registrantChangeId)
 			if err != nil {
 				resp.Diagnostics.AddError(
 					"failed to read DNSimple Registrant Change",
-					fmt.Sprintf("Unable to read registrant change for domain '%s' (ID: %d): %s", data.Name.ValueString(), data.Id.ValueInt64(), err.Error()),
+					fmt.Sprintf("Unable to read registrant change with ID %d for domain '%s': %s", registrantChangeId, data.Name.ValueString(), err.Error()),
 				)
 				return
 			}

--- a/internal/framework/resources/registered_domain/common.go
+++ b/internal/framework/resources/registered_domain/common.go
@@ -353,7 +353,13 @@ func tryToConvergeRegistrantChange(ctx context.Context, data *RegisteredDomainRe
 	return RegistrantChangeConverged, nil
 }
 
-func createRegistrantChange(ctx context.Context, data *RegisteredDomainResourceModel, r *RegisteredDomainResource, resp *resource.UpdateResponse) {
+// createRegistrantChange creates a registrant change and waits for it to complete.
+// It reports false when the caller must stop the update: either the API rejected the
+// change, or it was created but has not converged yet. The convergence timeout is
+// reported as a warning rather than an error, so callers cannot detect it from the
+// diagnostics alone -- continuing past it would save contact_id as if the change had
+// already taken effect.
+func createRegistrantChange(ctx context.Context, data *RegisteredDomainResourceModel, r *RegisteredDomainResource, resp *resource.UpdateResponse) bool {
 	registrantChangeAttributes := dnsimple.CreateRegistrantChangeInput{
 		DomainId:  fmt.Sprintf("%d", data.Id.ValueInt64()),
 		ContactId: fmt.Sprintf("%d", data.ContactId.ValueInt64()),
@@ -364,7 +370,7 @@ func createRegistrantChange(ctx context.Context, data *RegisteredDomainResourceM
 		diags := data.ExtendedAttributes.ElementsAs(ctx, &extendedAttrs, false)
 		resp.Diagnostics.Append(diags...)
 		if resp.Diagnostics.HasError() {
-			return
+			return false
 		}
 		registrantChangeAttributes.ExtendedAttributes = extendedAttrs
 	}
@@ -374,14 +380,14 @@ func createRegistrantChange(ctx context.Context, data *RegisteredDomainResourceM
 		var errorResponse *dnsimple.ErrorResponse
 		if errors.As(err, &errorResponse) {
 			resp.Diagnostics.Append(utils.AttributeErrorsToDiagnostics(errorResponse)...)
-			return
+			return false
 		}
 
 		resp.Diagnostics.AddError(
 			"failed to create DNSimple Registrant Change",
 			err.Error(),
 		)
-		return
+		return false
 	}
 
 	if registrantChangeResponse.Data.State != consts.RegistrantChangeStateCompleted {
@@ -390,7 +396,7 @@ func createRegistrantChange(ctx context.Context, data *RegisteredDomainResourceM
 				"failed to create DNSimple Registrant Change",
 				fmt.Sprintf("Registrant change creation failed with state '%s'", registrantChangeResponse.Data.State),
 			)
-			return
+			return false
 		}
 
 		// Registrant change has been created, but is not yet completed
@@ -398,7 +404,7 @@ func createRegistrantChange(ctx context.Context, data *RegisteredDomainResourceM
 			convergenceState, err := tryToConvergeRegistrantChange(ctx, data, &resp.Diagnostics, r, registrantChangeResponse.Data.Id)
 			if convergenceState == RegistrantChangeFailed {
 				// Response is already populated with the error we can safely return
-				return
+				return false
 			}
 
 			if convergenceState == RegistrantChangeConvergenceTimeout {
@@ -419,7 +425,7 @@ func createRegistrantChange(ctx context.Context, data *RegisteredDomainResourceM
 					"failed to converge on registrant change",
 					err.Error(),
 				)
-				return
+				return false
 			}
 
 			// This takes the registrant change ID, not the domain ID. Passing
@@ -432,7 +438,7 @@ func createRegistrantChange(ctx context.Context, data *RegisteredDomainResourceM
 					"failed to read DNSimple Registrant Change",
 					fmt.Sprintf("Unable to read registrant change with ID %d for domain '%s': %s", registrantChangeId, data.Name.ValueString(), err.Error()),
 				)
-				return
+				return false
 			}
 		}
 	}
@@ -443,4 +449,6 @@ func createRegistrantChange(ctx context.Context, data *RegisteredDomainResourceM
 
 	// Update the data with the current registrant change
 	data.RegistrantChange = registrantChangeObject
+
+	return true
 }

--- a/internal/framework/resources/registered_domain/resource_test.go
+++ b/internal/framework/resources/registered_domain/resource_test.go
@@ -144,6 +144,51 @@ func TestAccRegisteredDomainResource_RegistrantChange_WithExtendedAttrs(t *testi
 	})
 }
 
+func TestAccRegisteredDomainResource_RepeatedRegistrantChange(t *testing.T) {
+	domainName := os.Getenv("DNSIMPLE_REGISTRANT_CHANGE_DOMAIN")
+	contactID := os.Getenv("DNSIMPLE_REGISTRANT_CHANGE_CONTACT_ID")
+	contactID2 := os.Getenv("DNSIMPLE_REGISTRANT_CHANGE_CONTACT_ID_2")
+	resourceName := "dnsimple_registered_domain.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckRepeatedRegistrantChange(t) },
+		ProtoV6ProviderFactories: test_utils.TestAccProtoV6ProviderFactories(),
+		CheckDestroy:             testAccCheckRegisteredDomainRegistrantChangeDestroy,
+		Steps: []resource.TestStep{
+			{
+				// Import the existing domain
+				ResourceName:       resourceName,
+				Config:             testAccRegisteredDomainResourceConfig(domainName, "1234"),
+				ImportStateId:      domainName,
+				ImportState:        true,
+				ImportStateVerify:  false,
+				ImportStatePersist: true,
+			},
+			{
+				// First contact_id change
+				Config: testAccRegisteredDomainResourceConfig(domainName, contactID),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", domainName),
+					resource.TestCheckResourceAttrSet(resourceName, "registrant_change.id"),
+					resource.TestCheckResourceAttr(resourceName, "registrant_change.contact_id", contactID),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+			{
+				// Second contact_id change - previously failed with:
+				// "unexpected unknown property value for registrantChange"
+				Config: testAccRegisteredDomainResourceConfig(domainName, contactID2),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", domainName),
+					resource.TestCheckResourceAttrSet(resourceName, "registrant_change.id"),
+					resource.TestCheckResourceAttr(resourceName, "registrant_change.contact_id", contactID2),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func TestAccRegisteredDomainResource_WithOptions(t *testing.T) {
 	domainName := utils.RandomName("com", "options")
 	contactID := os.Getenv("DNSIMPLE_CONTACT_ID")
@@ -283,6 +328,13 @@ func testAccPreCheckRegistrantChange(t *testing.T) {
 	}
 	if os.Getenv("DNSIMPLE_REGISTRANT_CHANGE_DOMAIN") == "" {
 		t.Fatal("DNSIMPLE_REGISTRANT_CHANGE_DOMAIN must be set for acceptance tests")
+	}
+}
+
+func testAccPreCheckRepeatedRegistrantChange(t *testing.T) {
+	testAccPreCheckRegistrantChange(t)
+	if os.Getenv("DNSIMPLE_REGISTRANT_CHANGE_CONTACT_ID_2") == "" {
+		t.Fatal("DNSIMPLE_REGISTRANT_CHANGE_CONTACT_ID_2 must be set for acceptance tests")
 	}
 }
 

--- a/internal/framework/resources/registered_domain/resource_test.go
+++ b/internal/framework/resources/registered_domain/resource_test.go
@@ -147,9 +147,7 @@ func TestAccRegisteredDomainResource_RegistrantChange_WithExtendedAttrs(t *testi
 func TestAccRegisteredDomainResource_RepeatedRegistrantChange(t *testing.T) {
 	domainName := os.Getenv("DNSIMPLE_REGISTRANT_CHANGE_DOMAIN")
 	contactID := os.Getenv("DNSIMPLE_REGISTRANT_CHANGE_CONTACT_ID")
-	// Any second contact distinct from the first works here; reuse the one the other
-	// registered domain tests already rely on rather than requiring another variable.
-	contactID2 := os.Getenv("DNSIMPLE_CONTACT_ID")
+	contactID2 := os.Getenv("DNSIMPLE_REGISTRANT_CHANGE_CONTACT_ID_2")
 	resourceName := "dnsimple_registered_domain.test"
 
 	resource.Test(t, resource.TestCase{
@@ -333,13 +331,13 @@ func testAccPreCheckRegistrantChange(t *testing.T) {
 
 func testAccPreCheckRepeatedRegistrantChange(t *testing.T) {
 	testAccPreCheckRegistrantChange(t)
-	if os.Getenv("DNSIMPLE_CONTACT_ID") == "" {
-		t.Fatal("DNSIMPLE_CONTACT_ID must be set for acceptance tests")
+	if os.Getenv("DNSIMPLE_REGISTRANT_CHANGE_CONTACT_ID_2") == "" {
+		t.Fatal("DNSIMPLE_REGISTRANT_CHANGE_CONTACT_ID_2 must be set for acceptance tests")
 	}
 	// Both steps must be real registrant changes. If the two contacts match, the second
 	// step is a silent no-op and the test passes without exercising anything.
-	if os.Getenv("DNSIMPLE_CONTACT_ID") == os.Getenv("DNSIMPLE_REGISTRANT_CHANGE_CONTACT_ID") {
-		t.Fatal("DNSIMPLE_CONTACT_ID and DNSIMPLE_REGISTRANT_CHANGE_CONTACT_ID must differ for acceptance tests")
+	if os.Getenv("DNSIMPLE_REGISTRANT_CHANGE_CONTACT_ID_2") == os.Getenv("DNSIMPLE_REGISTRANT_CHANGE_CONTACT_ID") {
+		t.Fatal("DNSIMPLE_REGISTRANT_CHANGE_CONTACT_ID and DNSIMPLE_REGISTRANT_CHANGE_CONTACT_ID_2 must differ for acceptance tests")
 	}
 }
 

--- a/internal/framework/resources/registered_domain/resource_test.go
+++ b/internal/framework/resources/registered_domain/resource_test.go
@@ -147,7 +147,9 @@ func TestAccRegisteredDomainResource_RegistrantChange_WithExtendedAttrs(t *testi
 func TestAccRegisteredDomainResource_RepeatedRegistrantChange(t *testing.T) {
 	domainName := os.Getenv("DNSIMPLE_REGISTRANT_CHANGE_DOMAIN")
 	contactID := os.Getenv("DNSIMPLE_REGISTRANT_CHANGE_CONTACT_ID")
-	contactID2 := os.Getenv("DNSIMPLE_REGISTRANT_CHANGE_CONTACT_ID_2")
+	// Any second contact distinct from the first works here; reuse the one the other
+	// registered domain tests already rely on rather than requiring another variable.
+	contactID2 := os.Getenv("DNSIMPLE_CONTACT_ID")
 	resourceName := "dnsimple_registered_domain.test"
 
 	resource.Test(t, resource.TestCase{
@@ -172,7 +174,6 @@ func TestAccRegisteredDomainResource_RepeatedRegistrantChange(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "registrant_change.id"),
 					resource.TestCheckResourceAttr(resourceName, "registrant_change.contact_id", contactID),
 				),
-				ExpectNonEmptyPlan: true,
 			},
 			{
 				// Second contact_id change - previously failed with:
@@ -183,7 +184,6 @@ func TestAccRegisteredDomainResource_RepeatedRegistrantChange(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "registrant_change.id"),
 					resource.TestCheckResourceAttr(resourceName, "registrant_change.contact_id", contactID2),
 				),
-				ExpectNonEmptyPlan: true,
 			},
 		},
 	})
@@ -333,8 +333,13 @@ func testAccPreCheckRegistrantChange(t *testing.T) {
 
 func testAccPreCheckRepeatedRegistrantChange(t *testing.T) {
 	testAccPreCheckRegistrantChange(t)
-	if os.Getenv("DNSIMPLE_REGISTRANT_CHANGE_CONTACT_ID_2") == "" {
-		t.Fatal("DNSIMPLE_REGISTRANT_CHANGE_CONTACT_ID_2 must be set for acceptance tests")
+	if os.Getenv("DNSIMPLE_CONTACT_ID") == "" {
+		t.Fatal("DNSIMPLE_CONTACT_ID must be set for acceptance tests")
+	}
+	// Both steps must be real registrant changes. If the two contacts match, the second
+	// step is a silent no-op and the test passes without exercising anything.
+	if os.Getenv("DNSIMPLE_CONTACT_ID") == os.Getenv("DNSIMPLE_REGISTRANT_CHANGE_CONTACT_ID") {
+		t.Fatal("DNSIMPLE_CONTACT_ID and DNSIMPLE_REGISTRANT_CHANGE_CONTACT_ID must differ for acceptance tests")
 	}
 }
 

--- a/internal/framework/resources/registered_domain/schema.go
+++ b/internal/framework/resources/registered_domain/schema.go
@@ -5,8 +5,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -155,16 +153,10 @@ func (r *RegisteredDomainResource) Schema(_ context.Context, _ resource.SchemaRe
 					"contact_id": schema.Int64Attribute{
 						MarkdownDescription: "DNSimple contact ID for which the registrant change is being performed",
 						Computed:            true,
-						PlanModifiers: []planmodifier.Int64{
-							int64planmodifier.RequiresReplace(),
-						},
 					},
 					"domain_id": schema.StringAttribute{
 						MarkdownDescription: "DNSimple domain ID for which the registrant change is being performed",
 						Computed:            true,
-						PlanModifiers: []planmodifier.String{
-							stringplanmodifier.RequiresReplace(),
-						},
 					},
 					"state": schema.StringAttribute{
 						MarkdownDescription: "State of the registrant change",
@@ -178,9 +170,6 @@ func (r *RegisteredDomainResource) Schema(_ context.Context, _ resource.SchemaRe
 						MarkdownDescription: "Extended attributes for the registrant change",
 						ElementType:         types.StringType,
 						Computed:            true,
-						PlanModifiers: []planmodifier.Map{
-							mapplanmodifier.RequiresReplaceIfConfigured(),
-						},
 					},
 					"registry_owner_change": schema.BoolAttribute{
 						MarkdownDescription: "True if the registrant change will result in a registry owner change",
@@ -190,6 +179,9 @@ func (r *RegisteredDomainResource) Schema(_ context.Context, _ resource.SchemaRe
 						MarkdownDescription: "Date when the registrant change lock was lifted for the domain",
 						Computed:            true,
 					},
+				},
+				PlanModifiers: []planmodifier.Object{
+					objectplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"timeouts": schema.SingleNestedAttribute{

--- a/internal/framework/resources/registered_domain/schema.go
+++ b/internal/framework/resources/registered_domain/schema.go
@@ -180,9 +180,6 @@ func (r *RegisteredDomainResource) Schema(_ context.Context, _ resource.SchemaRe
 						Computed:            true,
 					},
 				},
-				PlanModifiers: []planmodifier.Object{
-					objectplanmodifier.UseStateForUnknown(),
-				},
 			},
 			"timeouts": schema.SingleNestedAttribute{
 				MarkdownDescription: "Timeouts for operations, given as a parsable string as in `10m` or `30s`.",

--- a/internal/framework/resources/registered_domain/update.go
+++ b/internal/framework/resources/registered_domain/update.go
@@ -117,7 +117,7 @@ func (r *RegisteredDomainResource) Update(ctx context.Context, req resource.Upda
 
 	var registrantChangeResponse *dnsimple.RegistrantChangeResponse
 	if planData.ContactId.ValueInt64() != stateData.ContactId.ValueInt64() {
-		if !registrantChange.Id.IsNull() {
+		if !registrantChange.Id.IsNull() && registrantChange.State.ValueString() != consts.RegistrantChangeStateCompleted {
 			convergenceState, _ := tryToConvergeRegistrantChange(ctx, planData, &resp.Diagnostics, r, int(registrantChange.Id.ValueInt64()))
 			if convergenceState == RegistrantChangeFailed {
 				// Response is already populated with the error we can safely return
@@ -155,11 +155,10 @@ func (r *RegisteredDomainResource) Update(ctx context.Context, req resource.Upda
 				)
 				return
 			}
-
-		} else {
-			// Create a new registrant change and handle any errors
-			createRegistrantChange(ctx, planData, r, resp)
 		}
+		// Pending registrant change has been converged or no pending change exists.
+		// Always create a new registrant change when contact_id differs.
+		createRegistrantChange(ctx, planData, r, resp)
 	} else if !registrantChange.Id.IsNull() && registrantChange.State.ValueString() != consts.RegistrantChangeStateCompleted {
 		registrantChangeResponse, err = r.config.Client.Registrar.GetRegistrantChange(ctx, r.config.AccountID, int(registrantChange.Id.ValueInt64()))
 		if err != nil {

--- a/internal/framework/resources/registered_domain/update.go
+++ b/internal/framework/resources/registered_domain/update.go
@@ -117,6 +117,20 @@ func (r *RegisteredDomainResource) Update(ctx context.Context, req resource.Upda
 
 	var registrantChangeResponse *dnsimple.RegistrantChangeResponse
 	if planData.ContactId.ValueInt64() != stateData.ContactId.ValueInt64() {
+		// The change recorded in state may already be moving the domain to the contact we
+		// are planning for. That is what the convergence timeout below leaves behind: it
+		// writes back only registrant_change, and because the framework seeds the update
+		// response from prior state, contact_id keeps its old value and the next plan
+		// asks for the same move again. Creating another change would duplicate one the
+		// domain has already been given.
+		//
+		// The change's own state is deliberately not part of this test. contact_id is
+		// never refreshed from the API, so a refresh between applies marks the recorded
+		// change completed while contact_id stays stale — which is precisely the case
+		// that must not create a second change.
+		alreadyTargetsPlannedContact := !registrantChange.Id.IsNull() &&
+			registrantChange.ContactId.ValueInt64() == planData.ContactId.ValueInt64()
+
 		if !registrantChange.Id.IsNull() && registrantChange.State.ValueString() != consts.RegistrantChangeStateCompleted {
 			convergenceState, _ := tryToConvergeRegistrantChange(ctx, planData, &resp.Diagnostics, r, int(registrantChange.Id.ValueInt64()))
 			if convergenceState == RegistrantChangeFailed {
@@ -156,9 +170,38 @@ func (r *RegisteredDomainResource) Update(ctx context.Context, req resource.Upda
 				return
 			}
 		}
-		// Pending registrant change has been converged or no pending change exists.
-		// Always create a new registrant change when contact_id differs.
-		createRegistrantChange(ctx, planData, r, resp)
+		if alreadyTargetsPlannedContact {
+			// The recorded change already targets the planned contact, so adopt it
+			// instead of creating a second one for the same move. Saving planData below
+			// also settles contact_id, so the next plan is empty rather than asking for
+			// the same move again.
+			registrantChangeResponse, err = r.config.Client.Registrar.GetRegistrantChange(ctx, r.config.AccountID, int(registrantChange.Id.ValueInt64()))
+			if err != nil {
+				resp.Diagnostics.AddError(
+					"failed to read DNSimple Registrant Change",
+					fmt.Sprintf("Unable to read registrant change with ID %d: %s", registrantChange.Id.ValueInt64(), err.Error()),
+				)
+				return
+			}
+
+			registrantChangeObject, diags := r.registrantChangeAPIResponseToObject(ctx, registrantChangeResponse.Data)
+			if diags.HasError() {
+				resp.Diagnostics.Append(diags...)
+				return
+			}
+			planData.RegistrantChange = registrantChangeObject
+		} else {
+			// A converged or absent pending change means this is a genuinely new move.
+			//
+			// Stop unless the change actually completed. A rejected change would
+			// otherwise let the update carry on mutating auto-renewal, WHOIS privacy,
+			// DNSSEC and the transfer lock, and a change still converging would be saved
+			// with contact_id set as though it had already taken effect. The convergence
+			// timeout is only a warning, so the diagnostics alone cannot detect it.
+			if !createRegistrantChange(ctx, planData, r, resp) {
+				return
+			}
+		}
 	} else if !registrantChange.Id.IsNull() && registrantChange.State.ValueString() != consts.RegistrantChangeStateCompleted {
 		registrantChangeResponse, err = r.config.Client.Registrar.GetRegistrantChange(ctx, r.config.AccountID, int(registrantChange.Id.ValueInt64()))
 		if err != nil {


### PR DESCRIPTION
Takes over #325 by @alexhuk3. The original commit is preserved with its authorship, and the follow-up work sits on top as separate commits.

## Problem

Changing `contact_id` on a `dnsimple_registered_domain` worked once. Every subsequent change failed.

`Update` only created a registrant change when state held none. Once a first change completed, state kept that object permanently, so later `contact_id` changes took the convergence branch against an already-completed change and never created a new one. The create call was reachable exactly once in the resource's lifetime.

## Change

**`update.go`** converges only a genuinely pending change, then creates a new one whenever `contact_id` differs.

**`schema.go`** drops `objectplanmodifier.UseStateForUnknown()` from `registrant_change`. That modifier pins the computed object to prior state, so a repeated change planned a known value while apply returned a newly created object, and Terraform rejected the mismatch:

```
Error: Provider produced inconsistent result after apply
... .registrant_change: was null, but now cty.ObjectVal({... "state":"completed"})
```

The `RequiresReplace` modifiers removed from the nested `contact_id`, `domain_id` and `extended_attributes` fields describe API results rather than practitioner inputs, and forcing replacement of a registered domain from them was never intended.

**Duplicate change guard.** The convergence-timeout path writes back only `registrant_change`, and the framework seeds `UpdateResponse.State` from prior state, so `contact_id` stays stale. The next plan asks for the same move again, and an unconditional create issues a second registrant change for a contact the domain already has. Registrant changes can be billable and can trigger a registry owner change. A recorded change already targeting the planned contact is now adopted instead.

The change's own state is excluded from that test on purpose. `contact_id` is never refreshed from the API, so a refresh between applies marks the recorded change completed while `contact_id` stays stale, which is the case that must not create a second change.

**`createRegistrantChange`** returns whether the caller may proceed. It reports a convergence timeout through a warning rather than an error, so checking diagnostics alone allowed the update to continue mutating auto-renewal, WHOIS privacy, DNSSEC and the transfer lock, and then save `contact_id` as though the change had taken effect.

**Pre-existing bug**, in its own commit: `GetRegistrantChange` was passed the domain ID where a registrant change ID belongs, which read an unrelated registrant change sharing that numeric ID or failed outright. Reachable before only on a first-ever registrant change; the restructure above routes every repeated change through it.

## Testing

`TestAccRegisteredDomainResource_RepeatedRegistrantChange` from the original PR performs two successive `contact_id` changes and passes against sandbox, with the registrant confirmed through the API to move across both steps. The whole `registered_domain` package passes.

The test needs two distinct contacts. `.github/workflows/test.yml` now sets `DNSIMPLE_REGISTRANT_CHANGE_CONTACT_ID_2` per matrix entry, pairing each `.eu` fixture domain with the contact it currently sits on (`dnsimple-tf-ci-1.eu` → 15562, `-2.eu` → 15561, `-3.eu` → 15560). Each domain moves to 14323 in the first step and back to its own contact in the second, so both steps are real changes and a run leaves the fixture as it found it. The precheck fails when the two contacts match, since the second step would otherwise be a silent no-op.

The test needs the fixture domain's registrant to differ from `DNSIMPLE_REGISTRANT_CHANGE_CONTACT_ID` at the start of a run. Consecutive runs alternate between the two contacts and stay valid.

## Merge order

Suggested after #372, which corrects behaviour already on `main`. Each related PR carries its own `CHANGELOG.md` entry, so expect a trivial conflict in the `## Unreleased` section for whichever merges after the first.