### PR TITLE
Backfill contact phone and fax on refresh after import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ BUG FIXES:
 
 - resource/`dnsimple_registered_domain`: Fix repeated `contact_id` updates failing after the first registrant change completed (#325)
 - resource/`dnsimple_registered_domain`: Pass the registrant change ID rather than the domain ID when re-reading a pending registrant change
+- resource/`dnsimple_contact`: Populate `phone` and `fax` from the API on refresh when state has no value for them, avoiding a spurious update immediately after import (#326)
 
 ## 2.1.2 - 2026-05-12
 

--- a/internal/framework/resources/contact_resource.go
+++ b/internal/framework/resources/contact_resource.go
@@ -337,7 +337,13 @@ func (r *ContactResource) updateModelFromAPIResponse(contact *dnsimple.Contact, 
 	data.PostalCode = types.StringValue(contact.PostalCode)
 	data.Country = types.StringValue(contact.Country)
 	data.PhoneNormalized = types.StringValue(contact.Phone)
+	if data.Phone.IsNull() || data.Phone.IsUnknown() || data.Phone.ValueString() == "" {
+		data.Phone = types.StringValue(contact.Phone)
+	}
 	data.FaxNormalized = types.StringValue(contact.Fax)
+	if data.Fax.IsNull() || data.Fax.IsUnknown() || data.Fax.ValueString() == "" {
+		data.Fax = types.StringValue(contact.Fax)
+	}
 	data.Email = types.StringValue(contact.Email)
 	data.CreatedAt = types.StringValue(contact.CreatedAt)
 	data.UpdatedAt = types.StringValue(contact.UpdatedAt)

--- a/internal/framework/resources/contact_resource.go
+++ b/internal/framework/resources/contact_resource.go
@@ -227,6 +227,7 @@ func (r *ContactResource) Read(ctx context.Context, req resource.ReadRequest, re
 	}
 
 	r.updateModelFromAPIResponse(response.Data, data)
+	r.backfillPhoneAndFaxFromAPIResponse(response.Data, data)
 
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -337,14 +338,29 @@ func (r *ContactResource) updateModelFromAPIResponse(contact *dnsimple.Contact, 
 	data.PostalCode = types.StringValue(contact.PostalCode)
 	data.Country = types.StringValue(contact.Country)
 	data.PhoneNormalized = types.StringValue(contact.Phone)
-	if data.Phone.IsNull() || data.Phone.IsUnknown() || data.Phone.ValueString() == "" {
-		data.Phone = types.StringValue(contact.Phone)
-	}
 	data.FaxNormalized = types.StringValue(contact.Fax)
-	if data.Fax.IsNull() || data.Fax.IsUnknown() || data.Fax.ValueString() == "" {
-		data.Fax = types.StringValue(contact.Fax)
-	}
 	data.Email = types.StringValue(contact.Email)
 	data.CreatedAt = types.StringValue(contact.CreatedAt)
 	data.UpdatedAt = types.StringValue(contact.UpdatedAt)
+}
+
+// backfillPhoneAndFaxFromAPIResponse fills the configurable phone and fax fields from
+// the API response when state carries no value for them, which is the case after an
+// import. Without this the fields stay empty and provoke a spurious update on the next
+// plan. It is only safe during refresh: phone is Required and fax is Optional+Computed
+// with an empty-string default, so overwriting either during create or update would
+// diverge from the planned value and trip Terraform's inconsistent-result check.
+//
+// Only null/unknown is backfilled, deliberately not empty string. After an import the
+// fields are null, so that covers the case this exists for. Treating "" as missing would
+// also pull a fax set outside Terraform into state on every refresh of a contact whose
+// config omits fax, since the schema defaults that attribute to "".
+func (r *ContactResource) backfillPhoneAndFaxFromAPIResponse(contact *dnsimple.Contact, data *ContactResourceModel) {
+	if data.Phone.IsNull() || data.Phone.IsUnknown() {
+		data.Phone = types.StringValue(contact.Phone)
+	}
+
+	if data.Fax.IsNull() || data.Fax.IsUnknown() {
+		data.Fax = types.StringValue(contact.Fax)
+	}
 }


### PR DESCRIPTION
Takes over #326, submitted by @alexhuk3 and authored by Oleksii.Shokariev. The original commit is preserved with its authorship, and the follow-up work sits on top as a separate commit.

## Problem

Importing a `dnsimple_contact` left `phone` and `fax` empty in state, even though the API returns values for both. The next plan then showed a diff and applied an update immediately after the import.

## Change

`Read` backfills `phone` and `fax` from the API response when state carries no value for them.

The follow-up commit moves this out of `updateModelFromAPIResponse`, which is shared by `Create`, `Read` and `Update`. Running the backfill on all three paths risks a different failure: `phone` is `Required` and `fax` is `Optional+Computed` with an empty-string default, so overwriting a planned value during create or update diverges from the plan and trips Terraform's inconsistent-result check. `backfillPhoneAndFaxFromAPIResponse` is now called only from `Read`, which still covers the import case, since import populates state through `Read`.

The condition covers null and unknown values only. Treating `""` as missing would pull a fax set outside Terraform into state on every refresh of a contact whose configuration omits `fax`, producing a recurring diff and an extra `UpdateContact` round-trip.

## Testing

`TestAccContactResource`, which includes an import step, passes against sandbox.

## Merge order

Independent of the other related PRs; touches only `contact_resource.go`. Each carries its own `CHANGELOG.md` entry, so expect a trivial conflict in the `## Unreleased` section for whichever merges after the first.

