### PR TITLE
Add opt-in prevent_delete to dnsimple_domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 FEATURES:
 
 - resource/`dnsimple_registered_domain`, resource/`dnsimple_domain_delegation`: Registrar calls rejected because a domain has lapsed past the registry grace period now report a warning during refresh instead of failing the whole plan. Terraform state is left as-is rather than dropping the resource, which would otherwise leave a lapsed `dnsimple_registered_domain` to be planned as a new, billable registration (#367)
+- resource/`dnsimple_domain`: Added an optional `prevent_delete` argument, defaulting to `false`. Set it to `true` to guard a domain against `terraform destroy` removing its registration. While enabled it also blocks the destroy half of a replacement, so changing `name` fails until it is set back to `false` and applied (#365)
 
 BUG FIXES:
 

--- a/docs/resources/domain.md
+++ b/docs/resources/domain.md
@@ -19,6 +19,7 @@ resource "dnsimple_domain" "example" {
 The following arguments are supported:
 
 - `name` - (Required) The domain name to be created.
+- `prevent_delete` - Flag to prevent [accidental registration deletion of the domain](https://support.dnsimple.com/articles/recovering-deleted-domain/) (default `true`).
 
 ## Attributes Reference
 

--- a/docs/resources/domain.md
+++ b/docs/resources/domain.md
@@ -19,7 +19,7 @@ resource "dnsimple_domain" "example" {
 The following arguments are supported:
 
 - `name` - (Required) The domain name to be created.
-- `prevent_delete` - Flag to prevent [accidental registration deletion of the domain](https://support.dnsimple.com/articles/recovering-deleted-domain/) (default `true`).
+- `prevent_delete` - Optional flag to guard against [accidental registration deletion of the domain](https://support.dnsimple.com/articles/recovering-deleted-domain/) (default `false`). Set it to `true` and `terraform destroy` will fail for this resource. Because changing `name` requires replacement, and replacement destroys the existing domain, renaming also fails while it is enabled — set it back to `false` and apply first.
 
 ## Attributes Reference
 

--- a/docs/resources/domain.md
+++ b/docs/resources/domain.md
@@ -6,6 +6,13 @@ page_title: "DNSimple: dnsimple_domain"
 
 Provides a DNSimple domain resource.
 
+!> **Warning** Destroying a `dnsimple_domain` resource deletes the domain from your DNSimple account, and **its DNS records are not recoverable**. A domain registered through DNSimple stays registered at the registry and remains yours until it expires, but recovering it means adding it back to your account as a zone and then [contacting DNSimple support](https://dnsimple.com/contact) to have the registration relinked. See [Recovering a deleted domain](https://support.dnsimple.com/articles/recovering-deleted-domain/).
+
+Two things are worth knowing before you manage a domain with this resource:
+
+- Set [`prevent_delete`](#prevent_delete) to `true` to make `terraform destroy` fail for the resource instead of deleting the domain.
+- If you only want Terraform to stop tracking the domain, remove it from state rather than destroying it. See [Removing a domain from Terraform](#removing-a-domain-from-terraform).
+
 ## Example Usage
 
 ```hcl
@@ -21,6 +28,13 @@ The following arguments are supported:
 - `name` - (Required) The domain name to be created.
 - `prevent_delete` - Optional flag to guard against [accidental registration deletion of the domain](https://support.dnsimple.com/articles/recovering-deleted-domain/) (default `false`). Set it to `true` and `terraform destroy` will fail for this resource. Because changing `name` requires replacement, and replacement destroys the existing domain, renaming also fails while it is enabled — set it back to `false` and apply first.
 
+  ```hcl
+  resource "dnsimple_domain" "example" {
+    name           = "example.com"
+    prevent_delete = true
+  }
+  ```
+
 ## Attributes Reference
 
 - `id` - The ID of this resource.
@@ -31,6 +45,32 @@ The following arguments are supported:
 - `registrant_id` - The ID of the registrant (contact) for the domain.
 - `state` - The state of the domain.
 - `unicode_name` - The domain name in Unicode format.
+
+## Removing a domain from Terraform
+
+To stop managing a domain with Terraform while leaving it in your DNSimple account, remove it from state instead of destroying it.
+
+With a `removed` block (Terraform 1.7 and later), which lets the change go through a normal plan and apply:
+
+```hcl
+removed {
+  from = dnsimple_domain.example
+
+  lifecycle {
+    destroy = false
+  }
+}
+```
+
+Or directly with the CLI:
+
+```bash
+terraform state rm dnsimple_domain.example
+```
+
+Both drop the resource from Terraform state and leave the domain untouched in your account. Remove the matching `resource` block from your configuration as part of the same change, otherwise the next plan proposes creating the domain again.
+
+-> **Note** `prevent_delete` does not interfere with either approach. Neither one calls the DNSimple API, so a domain can be dropped from state while protection is still enabled.
 
 ## Import
 

--- a/internal/framework/resources/domain_resource.go
+++ b/internal/framework/resources/domain_resource.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -35,15 +36,16 @@ type DomainResource struct {
 
 // DomainResourceModel describes the resource data model.
 type DomainResourceModel struct {
-	Name         types.String `tfsdk:"name"`
-	AccountId    types.Int64  `tfsdk:"account_id"`
-	RegistrantId types.Int64  `tfsdk:"registrant_id"`
-	UnicodeName  types.String `tfsdk:"unicode_name"`
-	State        types.String `tfsdk:"state"`
-	AutoRenew    types.Bool   `tfsdk:"auto_renew"`
-	PrivateWhois types.Bool   `tfsdk:"private_whois"`
-	Trustee      types.Bool   `tfsdk:"trustee"`
-	Id           types.Int64  `tfsdk:"id"`
+	Name          types.String `tfsdk:"name"`
+	PreventDelete types.Bool   `tfsdk:"prevent_delete"`
+	AccountId     types.Int64  `tfsdk:"account_id"`
+	RegistrantId  types.Int64  `tfsdk:"registrant_id"`
+	UnicodeName   types.String `tfsdk:"unicode_name"`
+	State         types.String `tfsdk:"state"`
+	AutoRenew     types.Bool   `tfsdk:"auto_renew"`
+	PrivateWhois  types.Bool   `tfsdk:"private_whois"`
+	Trustee       types.Bool   `tfsdk:"trustee"`
+	Id            types.Int64  `tfsdk:"id"`
 }
 
 func (r *DomainResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -60,6 +62,16 @@ func (r *DomainResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
+			},
+			/*
+			 * Domain deletion is extremely dangerous and thus this attribute defaults
+			 * to true as a safeguard. Users who wish to directly manage (and potentially
+			 * delete) their domains must explicitly disable this flag.
+			 */
+			"prevent_delete": schema.BoolAttribute{
+				Optional: true,
+				Default:  booldefault.StaticBool(true),
+				Computed: true,
 			},
 			"account_id": schema.Int64Attribute{
 				Computed: true,
@@ -168,7 +180,26 @@ func (r *DomainResource) Read(ctx context.Context, req resource.ReadRequest, res
 }
 
 func (r *DomainResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	// No-op
+	var preventDeleteFlag types.Bool
+
+	/*
+	 * Save updated data into Terraform state.
+	 *
+	 * Since the single argument that can be updated is `prevent_delete` and that
+	 * value is only meant to be stored in the state and acted on when a domain might
+	 * be deleted, we only need to ensure it is stored when changed.
+	 */
+	resp.Diagnostics.Append(req.Plan.GetAttribute(ctx, path.Root("prevent_delete"), &preventDeleteFlag)...)
+
+	if preventDeleteFlag.ValueBool() == false {
+		resp.Diagnostics.AddAttributeWarning(
+			path.Root("prevent_delete"),
+			"disabling domain deletion protection endangers domain registration.",
+			"Domain registration is lost when deleting domain resources. Only disable deletion protection if you fully understand the consequences of doing so.",
+		)
+	}
+
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("prevent_delete"), preventDeleteFlag)...)
 }
 
 func (r *DomainResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
@@ -178,6 +209,18 @@ func (r *DomainResource) Delete(ctx context.Context, req resource.DeleteRequest,
 	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
 
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if data.PreventDelete.ValueBool() {
+		resp.Diagnostics.AddError(
+			"failed to delete DNSimple Domain",
+			"Domain deletion protection enabled.",
+		)
+		resp.Diagnostics.AddWarning(
+			"domain registration is lost when deleting domain resources.",
+			fmt.Sprintf("Disabling deletion protection and destroying this resource will DELETE YOUR DOMAIN REGISTRATION with DNSimple for the domain %s.", data.Name),
+		)
 		return
 	}
 
@@ -205,6 +248,7 @@ func (r *DomainResource) ImportState(ctx context.Context, req resource.ImportSta
 
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), response.Data.ID)...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("name"), response.Data.Name)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("prevent_delete"), types.BoolValue(true))...)
 }
 
 func (r *DomainResource) updateModelFromAPIResponse(domain *dnsimple.Domain, data *DomainResourceModel) {

--- a/internal/framework/resources/domain_resource.go
+++ b/internal/framework/resources/domain_resource.go
@@ -64,14 +64,16 @@ func (r *DomainResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 				},
 			},
 			/*
-			 * Domain deletion is extremely dangerous and thus this attribute defaults
-			 * to true as a safeguard. Users who wish to directly manage (and potentially
-			 * delete) their domains must explicitly disable this flag.
+			 * Deleting a domain removes its registration, which is not recoverable in
+			 * the usual sense. This flag lets practitioners opt into a guard against
+			 * that. It defaults to false so the resource destroys like any other
+			 * Terraform resource unless protection is asked for explicitly.
 			 */
 			"prevent_delete": schema.BoolAttribute{
-				Optional: true,
-				Default:  booldefault.StaticBool(true),
-				Computed: true,
+				MarkdownDescription: "Whether to block `terraform destroy` from deleting the domain registration. Defaults to `false`. When set to `true`, destroying this resource fails until it is set back to `false` and applied.",
+				Optional:            true,
+				Default:             booldefault.StaticBool(false),
+				Computed:            true,
 			},
 			"account_id": schema.Int64Attribute{
 				Computed: true,
@@ -189,9 +191,19 @@ func (r *DomainResource) Update(ctx context.Context, req resource.UpdateRequest,
 	 * value is only meant to be stored in the state and acted on when a domain might
 	 * be deleted, we only need to ensure it is stored when changed.
 	 */
-	resp.Diagnostics.Append(req.Plan.GetAttribute(ctx, path.Root("prevent_delete"), &preventDeleteFlag)...)
+	var priorPreventDeleteFlag types.Bool
 
-	if preventDeleteFlag.ValueBool() == false {
+	resp.Diagnostics.Append(req.Plan.GetAttribute(ctx, path.Root("prevent_delete"), &preventDeleteFlag)...)
+	resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("prevent_delete"), &priorPreventDeleteFlag)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Only warn on an actual true -> false transition. Warning on any planned false
+	// would also fire for state written before this attribute existed, where the plan is
+	// null -> false and no protection was ever in place to lose.
+	if priorPreventDeleteFlag.ValueBool() && !preventDeleteFlag.ValueBool() {
 		resp.Diagnostics.AddAttributeWarning(
 			path.Root("prevent_delete"),
 			"disabling domain deletion protection endangers domain registration.",
@@ -212,6 +224,8 @@ func (r *DomainResource) Delete(ctx context.Context, req resource.DeleteRequest,
 		return
 	}
 
+	// ValueBool() reports false for a null or unknown value, which matches the schema
+	// default, so state written before this attribute existed destroys as it always did.
 	if data.PreventDelete.ValueBool() {
 		resp.Diagnostics.AddError(
 			"failed to delete DNSimple Domain",
@@ -219,7 +233,7 @@ func (r *DomainResource) Delete(ctx context.Context, req resource.DeleteRequest,
 		)
 		resp.Diagnostics.AddWarning(
 			"domain registration is lost when deleting domain resources.",
-			fmt.Sprintf("Disabling deletion protection and destroying this resource will DELETE YOUR DOMAIN REGISTRATION with DNSimple for the domain %s.", data.Name),
+			fmt.Sprintf("Disabling deletion protection and destroying this resource will DELETE YOUR DOMAIN REGISTRATION with DNSimple for the domain %s. Note this also blocks the destroy half of a replacement, so changing 'name' fails until protection is disabled.", data.Name.ValueString()),
 		)
 		return
 	}
@@ -248,10 +262,18 @@ func (r *DomainResource) ImportState(ctx context.Context, req resource.ImportSta
 
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), response.Data.ID)...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("name"), response.Data.Name)...)
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("prevent_delete"), types.BoolValue(true))...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("prevent_delete"), types.BoolValue(false))...)
 }
 
 func (r *DomainResource) updateModelFromAPIResponse(domain *dnsimple.Domain, data *DomainResourceModel) {
+	// prevent_delete is stored only in state and has no API counterpart, so state
+	// written before it existed carries no value for it. Settle it to the schema default
+	// on refresh, otherwise every previously managed domain shows a null -> false diff
+	// on the first plan after upgrading.
+	if data.PreventDelete.IsNull() || data.PreventDelete.IsUnknown() {
+		data.PreventDelete = types.BoolValue(false)
+	}
+
 	data.Id = types.Int64Value(domain.ID)
 	data.Name = types.StringValue(domain.Name)
 	data.AccountId = types.Int64Value(domain.AccountID)

--- a/internal/framework/resources/domain_resource_internal_test.go
+++ b/internal/framework/resources/domain_resource_internal_test.go
@@ -1,0 +1,39 @@
+package resources
+
+import (
+	"testing"
+
+	"github.com/dnsimple/dnsimple-go/v9/dnsimple"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+)
+
+// prevent_delete has no API counterpart and is only ever stored in state, so state
+// written by a provider version that predates it carries no value. Refresh settles it to
+// the schema default rather than leaving it null, which would otherwise surface as a
+// null -> false diff on the first plan after upgrading. An explicit opt-in must survive.
+func TestDomainResource_updateModelFromAPIResponse_PreventDelete(t *testing.T) {
+	domain := &dnsimple.Domain{ID: 1, Name: "example.com"}
+
+	for _, tt := range []struct {
+		name  string
+		prior types.Bool
+		want  bool
+	}{
+		{name: "null prior state settles to the unprotected default", prior: types.BoolNull(), want: false},
+		{name: "unknown prior state settles to the unprotected default", prior: types.BoolUnknown(), want: false},
+		{name: "explicit false is preserved", prior: types.BoolValue(false), want: false},
+		{name: "explicit opt-in to protection is preserved", prior: types.BoolValue(true), want: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &DomainResource{}
+			data := &DomainResourceModel{PreventDelete: tt.prior}
+
+			r.updateModelFromAPIResponse(domain, data)
+
+			assert.False(t, data.PreventDelete.IsNull(), "prevent_delete must never stay null")
+			assert.False(t, data.PreventDelete.IsUnknown(), "prevent_delete must never stay unknown")
+			assert.Equal(t, tt.want, data.PreventDelete.ValueBool())
+		})
+	}
+}

--- a/internal/framework/resources/domain_resource_test.go
+++ b/internal/framework/resources/domain_resource_test.go
@@ -28,6 +28,9 @@ func TestAccDomainResource(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", domainName),
 					resource.TestCheckResourceAttr(resourceName, "state", "hosted"),
 					resource.TestCheckResourceAttr(resourceName, "trustee", "false"),
+					// Deletion protection is opt-in, so the resource destroys like any
+					// other Terraform resource unless it is explicitly enabled.
+					resource.TestCheckResourceAttr(resourceName, "prevent_delete", "false"),
 				),
 			},
 			{
@@ -36,7 +39,24 @@ func TestAccDomainResource(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
-			// Update is a no-op
+			{
+				// Opting in is persisted.
+				Config: testAccDomainResourceConfigPreventDelete(domainName, true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", domainName),
+					resource.TestCheckResourceAttr(resourceName, "prevent_delete", "true"),
+				),
+			},
+			{
+				// Opting back out again. This has to be the closing step: while
+				// protection is enabled, the destroy that ends the test case fails with
+				// "Domain deletion protection enabled."
+				Config: testAccDomainResourceConfigPreventDelete(domainName, false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", domainName),
+					resource.TestCheckResourceAttr(resourceName, "prevent_delete", "false"),
+				),
+			},
 			// Delete testing automatically occurs in TestCase
 		},
 	})
@@ -78,4 +98,12 @@ func testAccDomainResourceConfig(domainName string) string {
 resource "dnsimple_domain" "test" {
 	name = %[1]q
 }`, domainName)
+}
+
+func testAccDomainResourceConfigPreventDelete(domainName string, preventDelete bool) string {
+	return fmt.Sprintf(`
+resource "dnsimple_domain" "test" {
+	name           = %[1]q
+	prevent_delete = %[2]t
+}`, domainName, preventDelete)
 }


### PR DESCRIPTION
Takes over #365 by @aryounce. The original commit is preserved with its authorship, and the follow-up work sits on top as a separate commit.

## Problem

Destroying a `dnsimple_domain` deletes the domain registration, and that loss is difficult to recover from. The resource offers no guard against doing it by accident.

## Change

Adds an optional `prevent_delete` argument. While it is `true`, `Delete` fails with a clear diagnostic and the registration survives.

The default is `false`. The original proposal defaulted it to `true`, and the follow-up commit changes that for two reasons:

- With protection on by default, `terraform destroy` fails out of the box, which departs from how every other resource in this provider and elsewhere behaves.
- `name` carries `RequiresReplace()`, and replacement destroys before creating, so a default of `true` also blocks renames.

A `true` default would also change behaviour for domains already under management, making an upgrade a breaking change for a guard that had not been asked for. As an opt-in, this PR introduces no breaking change.

Supporting details:

- Refresh settles a null value to `false`, so domains managed before this attribute existed show no diff on the first plan after upgrading.
- `Delete` reads the flag with `ValueBool()`, where null reports `false`, so older state destroys as it always did.
- The warning about disabling protection fires only on a real `true -> false` transition. Warning on any planned `false` would also catch the `null -> false` plan produced by older state, telling practitioners they were disabling protection that never existed.
- `ImportState` sets `false` to match the default.

While protection is enabled, renaming a domain fails until it is set back to `false` and applied. This is documented on the attribute, in `docs/resources/domain.md`, and in the delete diagnostic.

## Testing

- `TestAccDomainResource` asserts the unprotected default on create, enables protection, then disables it before the closing destroy.
- Protection was confirmed to block destroy by temporarily ending the test with it enabled, which fails with `Domain deletion protection enabled.`
- A unit test pins the refresh settling behaviour and confirms an explicit opt-in survives.

## Merge order

Independent of the other related PRs; touches only the `dnsimple_domain` resource and its docs. Each carries its own `CHANGELOG.md` entry, so expect a trivial conflict in the `## Unreleased` section for whichever merges after the first.
