### PR TITLE
Fix zone record priority validation and retry transient registrar reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 BUG FIXES:
 
 - resource/`dnsimple_zone_record`: Reject a non-zero `priority` on record types that do not carry one, rather than failing the apply with "Provider produced inconsistent result after apply". DNSimple stores a priority for MX and SRV records only (#360)
+- resource/`dnsimple_registered_domain`: Retry a transient registrar-connection failure during refresh, with backoff and a 30 second budget per domain, instead of aborting the whole plan. Every other error still fails immediately (#368)
 
 ## 2.2.0 - 2026-08-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+BUG FIXES:
+
+- resource/`dnsimple_zone_record`: Reject a non-zero `priority` on record types that do not carry one, rather than failing the apply with "Provider produced inconsistent result after apply". DNSimple stores a priority for MX and SRV records only (#360)
+
 ## 2.2.0 - 2026-08-04
 
 Thanks to the following people for contributing to this release: Santiago Traversa (#367), A. R. Younce (#365), Oleksii Shokariev (#325, #326) and Maksim Ryzhukhin (#325), and to @alexhuk3 for submitting #325 and #326.

--- a/docs/resources/zone_record.md
+++ b/docs/resources/zone_record.md
@@ -47,7 +47,7 @@ The following arguments are supported:
 - `value` - (Required) The value of the record.
 - `type` - (Required) The type of the record (e.g., `A`, `AAAA`, `CNAME`, `MX`, `TXT`). **The record type must be specified in UPPERCASE.**
 - `ttl` - (Optional) The TTL of the record. Defaults to `3600`.
-- `priority` - (Optional) The priority of the record. Only used for certain record types (e.g., `MX`, `SRV`).
+- `priority` - (Optional) The priority of the record. DNSimple stores a priority for `MX` and `SRV` records only, and discards it for every other type. Setting a non-zero priority on any other record type is rejected during validation.
 - `regions` - (Optional) A list of regions to serve the record from. You can find a list of supported values in our [developer documentation](https://developer.dnsimple.com/v2/zones/records/).
 
 

--- a/internal/framework/resources/registered_domain/read.go
+++ b/internal/framework/resources/registered_domain/read.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"time"
 
 	"github.com/dnsimple/dnsimple-go/v9/dnsimple"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -11,6 +12,50 @@ import (
 	"github.com/terraform-providers/terraform-provider-dnsimple/internal/consts"
 	"github.com/terraform-providers/terraform-provider-dnsimple/internal/framework/utils"
 )
+
+// Bounds on retrying a transient registrar failure during a refresh.
+//
+// The budget follows the 30s convention the create and update paths already use, and is
+// hardcoded rather than exposed as a `read` timeout: this retrying exists only until the
+// API gives transient failures a retryable status code (dnsimple/dnsimple-app#36024), and
+// a schema attribute added for it would outlive the reason for it.
+//
+// Backing off from 1s to 8s spends the budget on roughly six attempts, which covers a
+// momentary blip without holding a large workspace open on a registrar outage that is not
+// going to clear.
+const (
+	readRetryBudget       = 30 * time.Second
+	readRetryInitialDelay = 1 * time.Second
+	readRetryMaxDelay     = 8 * time.Second
+)
+
+// retryTransient runs an idempotent read against the DNSimple API, retrying it while it
+// fails with a transient registrar-connection error and returning every other error
+// unchanged on the first attempt.
+//
+// Read calls GetDomainRegistration, GetRegistrantChange, GetDomain, GetDnssec and
+// GetDomainTransferLock in sequence and treats any error as fatal, so a single blip on
+// any one of them aborts the whole plan. All five are reads with no side effects, which
+// is what makes retrying them safe.
+//
+// The deadline is passed in rather than derived from the budget here, so that one refresh
+// spends one budget across all five calls. Giving each call its own would let a single
+// domain add five times the budget to a plan during a flapping outage, and a plan
+// refreshes every registered domain in the workspace.
+func retryTransient[T any](ctx context.Context, deadline time.Time, fn func() (T, error)) (T, error) {
+	var result T
+
+	err := utils.RetryWithBackoff(ctx, func() (error, bool) {
+		var callErr error
+		result, callErr = fn()
+
+		// Suspend on anything that is not a transient registrar failure, so ordinary
+		// errors still surface immediately.
+		return callErr, callErr != nil && !utils.IsTransientRegistrarError(callErr)
+	}, time.Until(deadline), readRetryInitialDelay, readRetryMaxDelay)
+
+	return result, err
+}
 
 // warnDomainNoLongerRegistered reports that a registrar call was rejected because the
 // domain has lapsed, without failing the refresh. Callers return immediately afterwards,
@@ -40,6 +85,9 @@ func (r *RegisteredDomainResource) Read(ctx context.Context, req resource.ReadRe
 		return
 	}
 
+	// One budget for the whole refresh, shared by every call below.
+	retryDeadline := time.Now().Add(readRetryBudget)
+
 	domainRegistration, diags := getDomainRegistration(ctx, data)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
@@ -50,7 +98,9 @@ func (r *RegisteredDomainResource) Read(ctx context.Context, req resource.ReadRe
 	var err error
 	if !domainRegistration.Id.IsNull() {
 		domainRegistrationId := strconv.Itoa(int(domainRegistration.Id.ValueInt64()))
-		domainRegistrationResponse, err = r.config.Client.Registrar.GetDomainRegistration(ctx, r.config.AccountID, data.Name.ValueString(), domainRegistrationId)
+		domainRegistrationResponse, err = retryTransient(ctx, retryDeadline, func() (*dnsimple.DomainRegistrationResponse, error) {
+			return r.config.Client.Registrar.GetDomainRegistration(ctx, r.config.AccountID, data.Name.ValueString(), domainRegistrationId)
+		})
 		if err != nil {
 			if utils.IsDomainNotRegisteredOrExpiredError(err) {
 				warnDomainNoLongerRegistered(ctx, data.Name.ValueString(), resp)
@@ -73,7 +123,9 @@ func (r *RegisteredDomainResource) Read(ctx context.Context, req resource.ReadRe
 
 	var registrantChangeResponse *dnsimple.RegistrantChangeResponse
 	if !registrantChange.Id.IsNull() {
-		registrantChangeResponse, err = r.config.Client.Registrar.GetRegistrantChange(ctx, r.config.AccountID, int(registrantChange.Id.ValueInt64()))
+		registrantChangeResponse, err = retryTransient(ctx, retryDeadline, func() (*dnsimple.RegistrantChangeResponse, error) {
+			return r.config.Client.Registrar.GetRegistrantChange(ctx, r.config.AccountID, int(registrantChange.Id.ValueInt64()))
+		})
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"failed to read DNSimple Registrant Change",
@@ -90,7 +142,9 @@ func (r *RegisteredDomainResource) Read(ctx context.Context, req resource.ReadRe
 		data.RegistrantChange = registrantChangeObject
 	}
 
-	domainResponse, err := r.config.Client.Domains.GetDomain(ctx, r.config.AccountID, data.Name.ValueString())
+	domainResponse, err := retryTransient(ctx, retryDeadline, func() (*dnsimple.DomainResponse, error) {
+		return r.config.Client.Domains.GetDomain(ctx, r.config.AccountID, data.Name.ValueString())
+	})
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"failed to read DNSimple Domain",
@@ -103,7 +157,9 @@ func (r *RegisteredDomainResource) Read(ctx context.Context, req resource.ReadRe
 	var transferLock *dnsimple.DomainTransferLock
 
 	if domainResponse.Data.State == consts.DomainStateRegistered {
-		dnssecResponse, err := r.config.Client.Domains.GetDnssec(ctx, r.config.AccountID, data.Name.ValueString())
+		dnssecResponse, err := retryTransient(ctx, retryDeadline, func() (*dnsimple.DnssecResponse, error) {
+			return r.config.Client.Domains.GetDnssec(ctx, r.config.AccountID, data.Name.ValueString())
+		})
 		if err != nil {
 			if utils.IsDomainNotRegisteredOrExpiredError(err) {
 				warnDomainNoLongerRegistered(ctx, data.Name.ValueString(), resp)
@@ -118,7 +174,9 @@ func (r *RegisteredDomainResource) Read(ctx context.Context, req resource.ReadRe
 		}
 		dnssec = dnssecResponse.Data
 
-		transferLockResponse, err := r.config.Client.Registrar.GetDomainTransferLock(ctx, r.config.AccountID, data.Name.ValueString())
+		transferLockResponse, err := retryTransient(ctx, retryDeadline, func() (*dnsimple.DomainTransferLockResponse, error) {
+			return r.config.Client.Registrar.GetDomainTransferLock(ctx, r.config.AccountID, data.Name.ValueString())
+		})
 		if err != nil {
 			if utils.IsDomainNotRegisteredOrExpiredError(err) {
 				warnDomainNoLongerRegistered(ctx, data.Name.ValueString(), resp)

--- a/internal/framework/resources/zone_record_resource.go
+++ b/internal/framework/resources/zone_record_resource.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/dnsimple/dnsimple-go/v9/dnsimple"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -25,9 +26,11 @@ import (
 
 // Ensure the implementation satisfies the expected interfaces.
 var (
-	_ resource.Resource                = &ZoneRecordResource{}
-	_ resource.ResourceWithConfigure   = &ZoneRecordResource{}
-	_ resource.ResourceWithImportState = &ZoneRecordResource{}
+	_ resource.Resource                   = &ZoneRecordResource{}
+	_ resource.ResourceWithConfigure      = &ZoneRecordResource{}
+	_ resource.ResourceWithImportState    = &ZoneRecordResource{}
+	_ resource.ResourceWithValidateConfig = &ZoneRecordResource{}
+	_ resource.ResourceWithModifyPlan     = &ZoneRecordResource{}
 )
 
 func NewZoneRecordResource() resource.Resource {
@@ -57,6 +60,90 @@ type ZoneRecordResourceModel struct {
 
 func (r *ZoneRecordResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
 	resp.TypeName = req.ProviderTypeName + "_zone_record"
+}
+
+// checkPriorityAgainstRecordType reports a diagnostic when a record carries a priority
+// its type cannot hold.
+//
+// The DNSimple API stores a priority for MX and SRV records. For every other type it
+// discards the submitted value and returns null, which the client decodes as 0. Left
+// unchecked, the apply reaches Terraform's consistency check with a planned priority the
+// API never accepted and fails with "Provider produced inconsistent result after apply",
+// which reads as a provider defect rather than a configuration mistake.
+//
+// A priority of 0 passes for every type. It already matches what the API reports back, so
+// it applies cleanly today and rejecting it would break working configurations without
+// fixing anything.
+//
+// The MX/SRV set is about the API's separate priority attribute, which is a legacy of
+// splitting priority out of the record content. Newer priority-bearing types such as SVCB
+// and HTTPS carry their priority inside the content instead, so they do not belong here
+// and are correctly rejected. Revisit this set only if the API starts populating the
+// priority attribute for a further type; see dnsimple/terraform-provider-dnsimple#360.
+//
+// Either value may still be unknown when this runs, in which case there is nothing to
+// compare and the caller closer to apply performs the check instead.
+func checkPriorityAgainstRecordType(recordType types.String, priority types.Int64) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	if priority.IsNull() || priority.IsUnknown() || recordType.IsNull() || recordType.IsUnknown() {
+		return diags
+	}
+
+	if priority.ValueInt64() == 0 {
+		return diags
+	}
+
+	switch strings.ToUpper(recordType.ValueString()) {
+	case "MX", "SRV":
+		return diags
+	}
+
+	diags.AddAttributeError(
+		path.Root("priority"),
+		"priority is not supported for this record type",
+		fmt.Sprintf(
+			"DNSimple only stores a priority for MX and SRV records, and discards it for %s records. Remove the priority attribute from this resource.",
+			recordType.ValueString(),
+		),
+	)
+
+	return diags
+}
+
+// ValidateConfig catches the common case, where both values are written literally, and
+// reports it before any plan is produced.
+func (r *ZoneRecordResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var data ZoneRecordResourceModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(checkPriorityAgainstRecordType(data.Type, data.Priority)...)
+}
+
+// ModifyPlan catches values that were unknown during configuration validation.
+//
+// That covers references to resources that already exist, which resolve by planning time,
+// and also references to resources created in the same run: Terraform plans each resource
+// again during apply once its dependencies have resolved, so the real value reaches this
+// hook before the API is called. Create and Update therefore need no separate guard.
+func (r *ZoneRecordResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	// A destroy plan has no planned values to check.
+	if req.Plan.Raw.IsNull() {
+		return
+	}
+
+	var data ZoneRecordResourceModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(checkPriorityAgainstRecordType(data.Type, data.Priority)...)
 }
 
 func (r *ZoneRecordResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {

--- a/internal/framework/resources/zone_record_resource_test.go
+++ b/internal/framework/resources/zone_record_resource_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"regexp"
 	"strconv"
 	"testing"
 
@@ -91,6 +92,126 @@ func TestAccZoneRecordResourceWithPriority(t *testing.T) {
 			// Delete testing automatically occurs in TestCase
 		},
 	})
+}
+
+// The DNSimple API discards priority for record types that do not carry one and returns
+// null, which decodes as 0. Applying such a config used to fail Terraform's consistency
+// check with "Provider produced inconsistent result after apply", which reads as a
+// provider defect. Configuration is now rejected during validation instead.
+func TestAccZoneRecordResourcePriorityRejectedOnUnsupportedType(t *testing.T) {
+	domainName := os.Getenv("DNSIMPLE_DOMAIN")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { test_utils.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccZoneRecordResourcePriorityConfigForType(domainName, "prio-unsupported", "A", "1.2.3.4", 10),
+				ExpectError: regexp.MustCompile(`priority is not supported for this record type`),
+			},
+		},
+	})
+}
+
+// A zero priority reports back unchanged for every type, so it applies cleanly and must
+// keep doing so.
+func TestAccZoneRecordResourceZeroPriorityOnUnsupportedType(t *testing.T) {
+	domainName := os.Getenv("DNSIMPLE_DOMAIN")
+	resourceName := "dnsimple_zone_record.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { test_utils.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckZoneRecordResourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccZoneRecordResourcePriorityConfigForType(domainName, "prio-zero", "A", "1.2.3.4", 0),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "type", "A"),
+					resource.TestCheckResourceAttr(resourceName, "priority", "0"),
+				),
+			},
+		},
+	})
+}
+
+// SRV is the other type the API stores a priority for, so it must still apply.
+func TestAccZoneRecordResourcePriorityOnSRV(t *testing.T) {
+	domainName := os.Getenv("DNSIMPLE_DOMAIN")
+	resourceName := "dnsimple_zone_record.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { test_utils.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckZoneRecordResourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccZoneRecordResourcePriorityConfigForType(domainName, "_sip._tcp.prio-srv", "SRV", "5 5060 sip.example.com", 10),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "type", "SRV"),
+					resource.TestCheckResourceAttr(resourceName, "priority", "10"),
+				),
+			},
+		},
+	})
+}
+
+// A priority interpolated from an attribute that is only computed during apply is unknown
+// when the configuration is validated and when the run is first planned. Terraform plans
+// each resource again during apply, once its dependencies have resolved, so ModifyPlan
+// still sees the real value and reports it there. The error surfaces during apply rather
+// than at plan, but it replaces the inconsistent-result failure this change exists to
+// prevent.
+func TestAccZoneRecordResourcePriorityUnknownUntilApply(t *testing.T) {
+	domainName := os.Getenv("DNSIMPLE_DOMAIN")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { test_utils.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckZoneRecordResourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccZoneRecordResourcePriorityUnknownConfig(domainName),
+				ExpectError: regexp.MustCompile(`priority is not supported for this record type`),
+			},
+		},
+	})
+}
+
+func testAccZoneRecordResourcePriorityUnknownConfig(domainName string) string {
+	return fmt.Sprintf(`
+resource "dnsimple_zone_record" "source" {
+	zone_name = %[1]q
+
+	name = "prio-source"
+	value = "mail.example.com"
+	type = "MX"
+	ttl = 3600
+	priority = 10
+}
+
+resource "dnsimple_zone_record" "test" {
+	zone_name = %[1]q
+
+	name = "prio-unknown"
+	value = "1.2.3.4"
+	type = "A"
+	ttl = 3600
+	priority = dnsimple_zone_record.source.id
+}`, domainName)
+}
+
+func testAccZoneRecordResourcePriorityConfigForType(domainName, name, recordType, value string, priority int) string {
+	return fmt.Sprintf(`
+resource "dnsimple_zone_record" "test" {
+	zone_name = %[1]q
+
+	name = %[2]q
+	value = %[4]q
+	type = %[3]q
+	ttl = 3600
+	priority = %[5]d
+}`, domainName, name, recordType, value, priority)
 }
 
 func TestAccZoneRecordResourceWithTXT(t *testing.T) {

--- a/internal/framework/utils/utils.go
+++ b/internal/framework/utils/utils.go
@@ -73,6 +73,85 @@ func RetryWithTimeout(ctx context.Context, fn func() (error, bool), timeout time
 	}
 }
 
+// RetryWithBackoff behaves like RetryWithTimeout, but waits progressively longer between
+// attempts: the delay starts at initialDelay and doubles after each failure, up to
+// maxDelay. Retrying a struggling upstream on a fixed interval adds load at the worst
+// moment, and backing off gives it room to recover within the same overall budget.
+//
+// As with RetryWithTimeout, fn reports an error plus a suspend flag, and a suspended
+// error is returned without further attempts.
+//
+// initialDelay must be positive. A non-positive delay makes a single attempt rather than
+// retrying, because retrying with no wait at all would hammer an upstream that is already
+// struggling, which is the opposite of what any caller wants here.
+func RetryWithBackoff(ctx context.Context, fn func() (error, bool), timeout time.Duration, initialDelay time.Duration, maxDelay time.Duration) error {
+	deadline := time.Now().Add(timeout)
+
+	delay := initialDelay
+	if delay <= 0 {
+		delay = maxDelay
+	}
+
+	for {
+		err, suspend := fn()
+		if err == nil {
+			return nil
+		}
+
+		if suspend {
+			return err
+		}
+
+		// A non-positive delay would spin: the wait returns immediately and doubling never
+		// grows it, so fn would run flat out until the deadline.
+		if delay <= 0 {
+			return err
+		}
+
+		// Give up when the next wait would overrun the budget, rather than when the
+		// deadline has already passed. Checking after the fact lets the last wait run past
+		// the deadline by up to maxDelay, which makes the budget mean less than it says.
+		if time.Now().Add(delay).After(deadline) {
+			return err
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(delay):
+		}
+
+		if delay < maxDelay {
+			delay = min(delay*2, maxDelay)
+		}
+	}
+}
+
+// IsTransientRegistrarError returns true if err is a DNSimple API error reporting that
+// the upstream registrar connection failed, which is a momentary condition the same
+// request can recover from on a retry.
+//
+// The API renders this as HTTP 400 with a "please try again later" message across the
+// registrar-backed endpoints. A 4xx is otherwise a hard stop that a well-behaved client
+// never retries, so matching the message is the only signal available and this function
+// is deliberately a stopgap. dnsimple/dnsimple-app#36024 tracks giving the condition a
+// machine-readable status code; once that lands, this collapses to a status-code check
+// and the message matching goes away.
+//
+// The match is kept narrow for that reason: an unrelated 400 stays a hard stop.
+func IsTransientRegistrarError(err error) bool {
+	var errorResponse *dnsimple.ErrorResponse
+	if !errors.As(err, &errorResponse) {
+		return false
+	}
+
+	if errorResponse.HTTPResponse == nil || errorResponse.HTTPResponse.StatusCode != http.StatusBadRequest {
+		return false
+	}
+
+	return strings.Contains(strings.ToLower(errorResponse.Message), "registrar connection failed")
+}
+
 func AttributeErrorsToDiagnostics(err *dnsimple.ErrorResponse) diag.Diagnostics {
 	diagnostics := diag.Diagnostics{}
 

--- a/internal/framework/utils/utils_test.go
+++ b/internal/framework/utils/utils_test.go
@@ -1,9 +1,12 @@
 package utils_test
 
 import (
+	"context"
 	"errors"
 	"net/http"
+	"net/url"
 	"testing"
+	"time"
 
 	"github.com/dnsimple/dnsimple-go/v9/dnsimple"
 	"github.com/stretchr/testify/assert"
@@ -39,16 +42,20 @@ func TestHasUnicodeChars(t *testing.T) {
 	}
 }
 
-func TestIsDomainNotRegisteredOrExpiredError(t *testing.T) {
-	newErrorResponse := func(statusCode int, message string) error {
-		return &dnsimple.ErrorResponse{
-			Response: dnsimple.Response{
-				HTTPResponse: &http.Response{StatusCode: statusCode},
-			},
-			Message: message,
-		}
-	}
+func newErrorResponse(statusCode int, message string) error {
+	// ErrorResponse.Error() reads HTTPResponse.Request, so a request has to be present for
+	// the error to be printable — which testify does when an assertion about it fails.
+	request := &http.Request{Method: http.MethodGet, URL: &url.URL{Scheme: "https", Host: "api.dnsimple.com"}}
 
+	return &dnsimple.ErrorResponse{
+		Response: dnsimple.Response{
+			HTTPResponse: &http.Response{StatusCode: statusCode, Request: request},
+		},
+		Message: message,
+	}
+}
+
+func TestIsDomainNotRegisteredOrExpiredError(t *testing.T) {
 	tests := []struct {
 		name string
 		err  error
@@ -91,4 +98,183 @@ func TestIsDomainNotRegisteredOrExpiredError(t *testing.T) {
 			assert.Equal(t, tt.want, utils.IsDomainNotRegisteredOrExpiredError(tt.err))
 		})
 	}
+}
+
+func TestIsTransientRegistrarError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "the message the registrar endpoints actually return",
+			err:  newErrorResponse(http.StatusBadRequest, "Registrar connection failed, please try again later"),
+			want: true,
+		},
+		{
+			name: "matching 400 error with different casing",
+			err:  newErrorResponse(http.StatusBadRequest, "REGISTRAR CONNECTION FAILED, please try again later"),
+			want: true,
+		},
+		{
+			// An ordinary 400 is a hard stop and must not be retried, which is what keeps
+			// the stopgap match narrow.
+			name: "unrelated 400 error",
+			err:  newErrorResponse(http.StatusBadRequest, "Validation failed"),
+			want: false,
+		},
+		{
+			// The adjacent 400 the provider already classifies. The two must not overlap:
+			// a lapsed domain is permanent and retrying it would only delay the warning.
+			name: "domain not registered or expired",
+			err:  newErrorResponse(http.StatusBadRequest, "Change rejected: domain is not registered or expired"),
+			want: false,
+		},
+		{
+			name: "matching message but not a 400",
+			err:  newErrorResponse(http.StatusInternalServerError, "Registrar connection failed, please try again later"),
+			want: false,
+		},
+		{
+			name: "non-dnsimple error",
+			err:  errors.New("boom"),
+			want: false,
+		},
+		{
+			name: "nil error",
+			err:  nil,
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, utils.IsTransientRegistrarError(tt.err))
+		})
+	}
+}
+
+func TestRetryWithBackoff(t *testing.T) {
+	transient := newErrorResponse(http.StatusBadRequest, "Registrar connection failed, please try again later")
+
+	// The suspend flag the registered_domain read path passes: retry a transient registrar
+	// failure, stop on anything else.
+	retryTransientOnly := func(err error) (error, bool) {
+		return err, err != nil && !utils.IsTransientRegistrarError(err)
+	}
+
+	t.Run("returns immediately when the first attempt succeeds", func(t *testing.T) {
+		attempts := 0
+
+		err := utils.RetryWithBackoff(context.Background(), func() (error, bool) {
+			attempts++
+			return retryTransientOnly(nil)
+		}, time.Second, time.Millisecond, 10*time.Millisecond)
+
+		assert.NoError(t, err)
+		assert.Equal(t, 1, attempts)
+	})
+
+	t.Run("retries a transient failure until it clears", func(t *testing.T) {
+		attempts := 0
+
+		err := utils.RetryWithBackoff(context.Background(), func() (error, bool) {
+			attempts++
+			if attempts < 3 {
+				return retryTransientOnly(transient)
+			}
+			return retryTransientOnly(nil)
+		}, time.Second, time.Millisecond, 10*time.Millisecond)
+
+		assert.NoError(t, err)
+		assert.Equal(t, 3, attempts)
+	})
+
+	t.Run("does not retry a suspended error", func(t *testing.T) {
+		attempts := 0
+		permanent := newErrorResponse(http.StatusBadRequest, "Validation failed")
+
+		err := utils.RetryWithBackoff(context.Background(), func() (error, bool) {
+			attempts++
+			return retryTransientOnly(permanent)
+		}, time.Second, time.Millisecond, 10*time.Millisecond)
+
+		assert.Equal(t, permanent, err)
+		assert.Equal(t, 1, attempts, "a hard stop must surface on the first attempt")
+	})
+
+	t.Run("gives up at the budget and returns the last error", func(t *testing.T) {
+		attempts := 0
+
+		err := utils.RetryWithBackoff(context.Background(), func() (error, bool) {
+			attempts++
+			return retryTransientOnly(transient)
+		}, 20*time.Millisecond, time.Millisecond, 4*time.Millisecond)
+
+		assert.Equal(t, transient, err)
+		assert.Greater(t, attempts, 1, "the budget should allow more than one attempt")
+	})
+
+	t.Run("backs off, so a fixed budget spends fewer attempts than a fixed delay would", func(t *testing.T) {
+		attempts := 0
+
+		err := utils.RetryWithBackoff(context.Background(), func() (error, bool) {
+			attempts++
+			return retryTransientOnly(transient)
+		}, 100*time.Millisecond, 10*time.Millisecond, 40*time.Millisecond)
+
+		// Waits of 10ms + 20ms + 40ms put the fourth attempt at 70ms, and a further 40ms
+		// would overrun the budget, so it stops there. A fixed 10ms delay would have made
+		// roughly eleven attempts in the same budget.
+		assert.Equal(t, transient, err)
+		assert.LessOrEqual(t, attempts, 6)
+	})
+
+	t.Run("never starts a wait that would cross the budget", func(t *testing.T) {
+		attempts := 0
+
+		err := utils.RetryWithBackoff(context.Background(), func() (error, bool) {
+			attempts++
+			return retryTransientOnly(transient)
+		}, 50*time.Millisecond, 10*time.Millisecond, 40*time.Millisecond)
+
+		// Waits of 10ms and 20ms put the third attempt at 30ms, and a further 40ms would
+		// cross the 50ms budget, so it stops there. Checking the deadline only after
+		// waiting would instead sleep that 40ms and make a fourth attempt at 70ms.
+		//
+		// This asserts the attempt count rather than elapsed time on purpose: time.After
+		// only guarantees a lower bound, so a loaded runner can overshoot the budget
+		// without the implementation being wrong. Overshoot can only lower the attempt
+		// count, never raise it, so the bound below cannot flake upward.
+		assert.Equal(t, transient, err)
+		assert.LessOrEqual(t, attempts, 3)
+	})
+
+	t.Run("makes a single attempt rather than spinning when given no delay", func(t *testing.T) {
+		attempts := 0
+
+		err := utils.RetryWithBackoff(context.Background(), func() (error, bool) {
+			attempts++
+			return retryTransientOnly(transient)
+		}, time.Minute, 0, 0)
+
+		// Doubling never grows a zero delay, so retrying here would run fn flat out for a
+		// full minute against an upstream that is already failing.
+		assert.Equal(t, transient, err)
+		assert.Equal(t, 1, attempts)
+	})
+
+	t.Run("stops when the context is cancelled", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		attempts := 0
+
+		err := utils.RetryWithBackoff(ctx, func() (error, bool) {
+			attempts++
+			cancel()
+			return retryTransientOnly(transient)
+		}, time.Minute, time.Millisecond, time.Millisecond)
+
+		assert.ErrorIs(t, err, context.Canceled)
+		assert.Equal(t, 1, attempts)
+	})
 }


### PR DESCRIPTION
Carries two independent fixes, one per commit. Happy to split into separate PRs if preferred.

## Problem

**`priority` on `dnsimple_zone_record` (#360).** `priority` is `Optional+Computed`. DNSimple stores a priority for MX and SRV records only. For every other type the API discards the submitted value and returns null, which the client decodes as `0`. Setting `priority = 10` on an A record therefore planned `10` and read back `0`, failing Terraform's consistency check:

```
Error: Provider produced inconsistent result after apply
... .priority: was cty.NumberIntVal(10), but now cty.NumberIntVal(0).
```

That reads as a provider defect rather than a configuration mistake, and there was no way to apply the config at all. The reporter's workaround was to remove the attribute.

**Transient registrar failures on `dnsimple_registered_domain` (#368).** `Read` calls `GetDomainRegistration`, `GetRegistrantChange`, `GetDomain`, `GetDnssec` and `GetDomainTransferLock` in sequence and treats every error as fatal. The API reports a momentary upstream registrar failure as HTTP 400 `Registrar connection failed, please try again later`, so a single blip aborts the plan:

```
Error: failed to read DNSimple Domain Transfer Lock status
Unable to read transfer lock status for domain 'domain.tld':
... 400 Registrar connection failed, please try again later
```

A plan refreshes every registered domain in the workspace, so in a large workspace this is a recurring source of CI failures.

## Change

**`zone_record_resource.go`** rejects a non-zero `priority` on types that do not carry one, with a message naming the types that do. `ValidateConfig` catches literal configurations at plan time. `ModifyPlan` catches values that are unknown when the configuration is validated, including references to resources created in the same run, since Terraform plans each resource again during apply once its dependencies resolve. `Create` and `Update` need no separate guard.

A priority of `0` is left alone for every type. It already matches what the API reports back, so it applies cleanly today and rejecting it would break working configurations without fixing anything.

The MX/SRV set covers the API's separate `priority` attribute, which is a legacy of splitting priority out of record content. Newer priority-bearing types such as SVCB and HTTPS carry their priority inside the content, so they are correctly rejected here. This is recorded in a comment so a future type addition finds it.

**`utils.IsTransientRegistrarError`** classifies on the typed `dnsimple.ErrorResponse`, status code plus message, matching the existing `IsDomainNotRegisteredOrExpiredError` rather than matching raw error text.

Matching the message is a stopgap. A 4xx is otherwise a hard stop that clients must never retry, and dnsimple/dnsimple-app#36024 tracks giving this condition a retryable status code. Once that lands the match collapses to a status code check and the message matching goes away. The substring is kept narrow so an unrelated 400 stays a hard stop. The two 400 classifiers do not overlap, and a lapsed domain still reaches its existing warning intact.

**`utils.RetryWithBackoff`** grows the delay between attempts instead of using a fixed interval, since retrying a struggling upstream at a fixed rate adds load at the worst moment. It keeps the `(error, bool)` suspend contract of `RetryWithTimeout`, and existing callers are untouched. It gives up when the next wait would cross the deadline rather than after the fact, so the budget means what it says.

**`registered_domain/read.go`** wraps all five reads. They are GETs with no side effects, which is what makes retrying them safe. Every other error still surfaces on the first attempt.

One 30s budget covers the whole refresh rather than each call, so a single domain cannot add five times the budget to a plan. Backing off from 1s to 8s spends it on roughly six attempts. The budget is hardcoded rather than exposed as a `read` timeout, because this retrying exists only until the API change lands and a schema attribute added for it would outlive the reason for it.

## Testing

`go build`, `go vet`, `gofmt` and the unit suite pass. `golangci-lint` on the touched packages reports only issues that pre-date this branch.

Acceptance tests for #360, against sandbox:

- `TestAccZoneRecordResourcePriorityRejectedOnUnsupportedType` covers an A record with a priority.
- `TestAccZoneRecordResourceZeroPriorityOnUnsupportedType` pins that a zero priority still applies.
- `TestAccZoneRecordResourcePriorityOnSRV` covers the other type the API stores a priority for. The existing `TestAccZoneRecordResourceWithPriority` only covered MX, which is why this went unnoticed.
- `TestAccZoneRecordResourcePriorityUnknownUntilApply` covers a priority interpolated from a resource created in the same run. The error surfaces during apply rather than at plan, and it replaces the inconsistent-result failure.

Unit coverage for #368 spans status code, message wording, casing and non-DNSimple errors for the matcher, and success, retry-then-recover, suspend, budget exhaustion, backoff growth, deadline overrun and context cancellation for the retry helper. A test asserts the two 400 matchers do not overlap.

The retry wiring in `read.go` has no end-to-end coverage. `registered_domain` has only acceptance tests against the live API, and a transient 400 followed by a success cannot be produced on demand. Exercising it needs a mocked HTTP harness, which does not exist for this resource. That is being looked at separately, since it is worth more than this change alone.

## Merge order

Independent of the open dependabot PR. Both commits add to the same `## Unreleased` block in `CHANGELOG.md`, so expect a trivial conflict there for whichever merges after the first.
